### PR TITLE
Proposition d'organisation pour les tests e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,21 @@ test-watch: ## launch all tests in docker
 		cd ../../ && \
 		yarn test:watch \
 	'
+test-e2e: ## Run whole e2e tests suite
+	@${MAKE} --quiet test-env-start
+	@($(MAKE) --quiet test-env-run && $(MAKE) --quiet test-env-stop) || ($(MAKE) --quiet test-env-stop && exit 1)
 
-test-application-start: build-front 
+test-env-start: build-front 
 	@${DC_TEST} up -d
-test-application-stop:
+test-env-stop:
 	@${DC_TEST} down
-test-application-logs:
+test-env-logs:
 	@${DC_TEST} logs -f
+test-env-run:
+	@${DC_TEST} run --rm jobboard ash -ci '\
+		cd ../../tests-e2e && \
+		yarn test \
+	'
 
 # =====================================================================
 # Build ===============================================================

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ logs: ## Display all logs
 # Testing =============================================================
 # =====================================================================
 
+DC_TEST = docker-compose -p cc-jobboard-test -f docker-compose-test.yml
+
 test: ## launch all tests in docker
 	@docker-compose run --rm --no-deps api ash -ci '\
 		cd ../../ && \
@@ -46,6 +48,13 @@ test-watch: ## launch all tests in docker
 		cd ../../ && \
 		yarn test:watch \
 	'
+
+test-application-start: build-front 
+	@${DC_TEST} up -d
+test-application-stop:
+	@${DC_TEST} down
+test-application-logs:
+	@${DC_TEST} logs -f
 
 # =====================================================================
 # Build ===============================================================

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,19 @@ export NODE_ENV ?= development
 help: ## Display available commands
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+# =====================================================================
+# Initialization ======================================================
+# =====================================================================
+
 install: ## Install all js deps
 	@docker-compose run --rm --no-deps api ash -ci '\
 		cd ../../ && \
 		yarn \
 	'
+
+# =====================================================================
+# Operating recipies ==================================================
+# =====================================================================
 
 start: ## Start all service in containers
 	docker-compose up -d
@@ -22,6 +30,10 @@ stop: ## Stop all containers
 
 logs: ## Display all logs
 	docker-compose logs -f
+
+# =====================================================================
+# Testing =============================================================
+# =====================================================================
 
 test: ## launch all tests in docker
 	@docker-compose run --rm --no-deps api ash -ci '\
@@ -33,4 +45,14 @@ test-watch: ## launch all tests in docker
 	@docker-compose run --rm --no-deps api ash -ci '\
 		cd ../../ && \
 		yarn test:watch \
+	'
+
+# =====================================================================
+# Build ===============================================================
+# =====================================================================
+
+build-front: ## Build the front
+	@docker-compose run --rm --no-deps front ash -ci '\
+		rm -f public/bundle.* && \
+		yarn build \
 	'

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     },
     "scripts": {
         "dev": "nodemon --watch src src/index.js",
+        "start": "nodemon --watch src src/index.js",
         "test": "jest",
         "test:watch": "jest --watchAll"
     },
@@ -17,6 +18,8 @@
         "url": "https://github.com/CaenCamp/jobs-caen-camp/issues"
     },
     "dependencies": {
-        "koa": "2.11.0"
+        "koa": "2.11.0",
+        "koa-router": "7.4.0",
+        "koa-static": "5.0.0"
     }
 }

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -1,8 +1,26 @@
 const Koa = require('koa');
-const app = new Koa();
+const Router = require('koa-router');
+const serve = require('koa-static');
 
-app.use(async ctx => {
-    ctx.body = { message: 'Hello CaenCamp Jobboard' };
+const app = new Koa();
+const router = new Router();
+const env = process.env.NODE_ENV;
+
+if (env === 'development') {
+    router.get('/', ctx => {
+        ctx.body = {
+            message:
+                'Front is not serve here in dev environment. See documentation. API is available on /api endpoint',
+        };
+    });
+} else {
+    app.use(serve(`${__dirname}/../../front/public`));
+}
+
+router.get('/api', ctx => {
+    ctx.body = { message: 'CaenCamp Jobboard API' };
 });
+
+app.use(router.routes()).use(router.allowedMethods());
 
 app.listen(3001, () => global.console.log('API started on port 3001'));

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+
+services:
+  jobboard:
+    image: node:12.14-alpine
+    volumes:
+      - .:/jobboard
+    working_dir: '/jobboard/apps/api'
+    user: '${UID}:${GID}'
+    ports:
+      - 8000:3001
+    environment:
+      - NODE_ENV='test'
+    command: 'yarn start'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     user: '${UID}:${GID}'
     ports:
       - 8001:3001
+    environment:
+      - NODE_ENV='development'
     command: 'yarn dev'
 
   api-moked:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "cypress": "3.8.1",
         "eslint": "6.8.0",
         "eslint-config-prettier": "6.9.0",
-        "eslint-plugin-jest": "23.1.1",
+        "eslint-plugin-jest": "23.2.0",
         "eslint-plugin-prettier": "3.1.2",
         "eslint-plugin-svelte3": "2.7.3",
         "frisby": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "private": true,
     "version": "1.0.0",
     "workspaces": [
-        "apps/*"
+        "apps/*",
+        "tests-e2e"
     ],
     "scripts": {
         "test": "jest",

--- a/tests-e2e/.eslintrc.json
+++ b/tests-e2e/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": 2019
+    },
+    "extends": ["eslint:recommended", "plugin:jest/recommended"],
+    "rules": {
+        "prefer-expect-assertions": 0
+    }
+}

--- a/tests-e2e/.prettierrc
+++ b/tests-e2e/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": true
+}

--- a/tests-e2e/README.md
+++ b/tests-e2e/README.md
@@ -1,0 +1,3 @@
+# Tests e2e de l'application jobBoard
+
+Il ne s'agit pas ici d'une application, mais de l'ensemble des tests e2e effectué sur l'application jobBoard.

--- a/tests-e2e/api/index.spec.js
+++ b/tests-e2e/api/index.spec.js
@@ -1,0 +1,24 @@
+import frisby from 'frisby';
+const Joi = frisby.Joi;
+
+describe('jobBoard API endpoint', () => {
+    describe('/api', () => {
+        it('devrait renvoyer un simple message de bienvenue', async () => {
+            expect.hasAssertions();
+            await frisby
+                .get('http://jobboard:3001/api')
+                .expect('status', 200)
+                .expect(
+                    'header',
+                    'Content-Type',
+                    'application/json; charset=utf-8'
+                )
+                .expect('jsonTypes', 'message', Joi.string().required())
+                .then(resp => {
+                    expect(resp.json.message).toStrictEqual(
+                        'CaenCamp Jobboard API'
+                    );
+                });
+        });
+    });
+});

--- a/tests-e2e/babel.config.js
+++ b/tests-e2e/babel.config.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    presets: [
+        [
+            '@babel/preset-env',
+            {
+                targets: {
+                    node: 'current',
+                },
+            },
+        ],
+    ],
+};

--- a/tests-e2e/jest.config.js
+++ b/tests-e2e/jest.config.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line no-undef
+module.exports = {
+    name: 'e2e',
+    displayName: 'Tests e2e',
+    rootDir: '.',
+    resetMocks: true,
+    resetModules: true,
+    verbose: true,
+    transform: {
+        '^.+\\.js$': 'babel-jest',
+    },
+    moduleFileExtensions: ['js'],
+    testPathIgnorePatterns: ['node_modules'],
+    transformIgnorePatterns: ['node_modules'],
+};

--- a/tests-e2e/package.json
+++ b/tests-e2e/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "cc-jobboard-tests-e2e",
+    "version": "1.0.0",
+    "description": "Tests e2e mage on jobBoard app (api and front)",
+    "scripts": {
+        "test": "jest",
+        "test:watch": "jest --watchAll"
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,7 +1369,7 @@ any-observable@^0.3.0:
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
   integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
-any-promise@^1.1.0:
+any-promise@^1.0.0, any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
@@ -3648,7 +3648,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@^1.6.3, http-errors@~1.7.2:
+http-errors@^1.3.1, http-errors@^1.6.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -3658,6 +3658,16 @@ http-errors@^1.6.3, http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4811,6 +4821,36 @@ koa-convert@^1.2.0:
     co "^4.6.0"
     koa-compose "^3.0.0"
 
+koa-router@7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/koa-router/-/koa-router-7.4.0.tgz#aee1f7adc02d5cb31d7d67465c9eacc825e8c5e0"
+  integrity sha512-IWhaDXeAnfDBEpWS6hkGdZ1ablgr6Q6pGdXCyK38RbzuH4LkUOpPqPw+3f8l8aTDrQmBQ7xJc0bs2yV4dzcO+g==
+  dependencies:
+    debug "^3.1.0"
+    http-errors "^1.3.1"
+    koa-compose "^3.0.0"
+    methods "^1.0.1"
+    path-to-regexp "^1.1.1"
+    urijs "^1.19.0"
+
+koa-send@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.0.tgz#5e8441e07ef55737734d7ced25b842e50646e7eb"
+  integrity sha512-90ZotV7t0p3uN9sRwW2D484rAaKIsD8tAVtypw/aBU+ryfV+fR2xrcAwhI8Wl6WRkojLUs/cB9SBSCuIb+IanQ==
+  dependencies:
+    debug "^3.1.0"
+    http-errors "^1.6.3"
+    mz "^2.7.0"
+    resolve-path "^1.4.0"
+
+koa-static@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-5.0.0.tgz#5e92fc96b537ad5219f425319c95b64772776943"
+  integrity sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==
+  dependencies:
+    debug "^3.1.0"
+    koa-send "^5.0.0"
+
 koa@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/koa/-/koa-2.11.0.tgz#fe5a51c46f566d27632dd5dc8fd5d7dd44f935a4"
@@ -5288,7 +5328,7 @@ method-override@^3.0.0:
     parseurl "~1.3.2"
     vary "~1.1.2"
 
-methods@~1.1.2:
+methods@^1.0.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -5447,6 +5487,15 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nan@^2.12.1:
   version "2.14.0"
@@ -5940,7 +5989,7 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@^1.0.0:
+path-is-absolute@1.0.1, path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -5970,7 +6019,7 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.0.3:
+path-to-regexp@^1.0.3, path-to-regexp@^1.1.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
@@ -6543,6 +6592,14 @@ resolve-global@1.0.0, resolve-global@^1.0.0:
   dependencies:
     global-dirs "^0.1.1"
 
+resolve-path@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
+  integrity sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=
+  dependencies:
+    http-errors "~1.6.2"
+    path-is-absolute "1.0.1"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -6865,6 +6922,11 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
+
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
@@ -7101,7 +7163,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.5.0 < 2", statuses@^1.5.0, statuses@~1.5.0:
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0, statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -7375,6 +7437,20 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
+  dependencies:
+    any-promise "^1.0.0"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -7714,6 +7790,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+urijs@^1.19.0:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
+  integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
 
 urix@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,10 +2745,10 @@ eslint-config-prettier@6.9.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-plugin-jest@23.1.1:
-  version "23.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.1.1.tgz#1220ab53d5a4bf5c3c4cd07c0dabc6199d4064dd"
-  integrity sha512-2oPxHKNh4j1zmJ6GaCBuGcb8FVZU7YjFUOJzGOPnl9ic7VA/MGAskArLJiRIlnFUmi1EUxY+UiATAy8dv8s5JA==
+eslint-plugin-jest@23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.2.0.tgz#72d9ac0421b9b6ef774bcf4783329c016ed7cd6a"
+  integrity sha512-/jbCUW+g0jejXAvsytgcNhii6uEgolt0RO2e4+mhmXybfkcram5V3XIyrHCnUsb0vCmDKgHhJ1lYSm7F3VCEDA==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 


### PR DESCRIPTION
## Description

Cette PR est une **proposition** d'organisation des tests e2e.

L'idée est de bien séparer les tests e2e du reste du code. Les tests unitaires restent *proche* du code testé, mais les tests e2e sont isolés dans le répertoire `/tests-e2e`. De plus, ils sont joués sur une application *buildée* proche de l'environnement de production. 

**Mais encore une fois, ce n'est qu'une proposition**. Cela correspond à la manière dont je gère le plus souvent ce type de tests au quotidien ! C'est donc une facilité pour moi de faire cette proposition, et je serais ravi d'enrichir ma manière de faire par d'autres propositions. Ce qui ne veux pas dire que je pense que cette manière de faire est mauvaise ^^ D'ailleur je compte bien la défendre avec des arguments ! 

### Le pour

* On teste sur ce qui peut se rapprocher le plus de l'environnement final. On a plus par exemple le biais du serveur de dev de rollup pour le front.
* On isole les tests e2e, et tous les fichiers qui peuvent y être liés, comme les fixtures, du code proprement dit (séparation en `/tests-e2e` et `/apps`).

### Le contre

* On introduit de la complexité, entre autre dans le `Makefile`.
* On rend presque obligatoire l'utilisation de Docker et Docker Compose.

> *Rq: les tests e2e du front, c'est à dire avec Cypress ainsi que la doc n'ont pas encore été mis à jours.*

![test-e2e](https://user-images.githubusercontent.com/547706/71555988-ce886c80-2a32-11ea-94fd-48818cac781b.gif)

## Related Issue

#9 Mise en place des tests

