### PR TITLE
feat: generate fake organizations and offers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "env": {
-        "cypress/globals": true
+        "cypress/globals": true,
+        "node": true
     },
     "extends": [
         "eslint:recommended",

--- a/apps/api-mocked/README.md
+++ b/apps/api-mocked/README.md
@@ -1,5 +1,10 @@
 # Site des offres d'emploi des CaenCamp: l'API simulée
 
-L'architecture du projet se base donc sur une [API](../api/README.md) qui sera utilisée par une [application web](../front/README.md). Afin de faciliter le démarrage du projet (par exemple de commencer le dev de l'application web sans attendre que l'API soit codée), nous avons mis en place un serveur d'API *mocké*.
+L'architecture du projet se base donc sur une [API](../api/README.md) qui sera utilisée par une [application web](../front/README.md). Afin de faciliter le démarrage du projet (par exemple de commencer le dev de l'application web sans attendre que l'API soit codée), nous avons mis en place un serveur d'API _mocké_.
 
 Ce serveur utilise [json-server](https://github.com/typicode/json-server), et le modèle est défini dans le fichier `db.json`.
+
+## Schemas
+
+-   [Organization](http://schema.org/Organization)
+-   [Offer](http://schema.org/JobPosting)

--- a/apps/api-mocked/db.json
+++ b/apps/api-mocked/db.json
@@ -1,9 +1,0 @@
-{
-    "jobs": [
-        {
-            "id": 1,
-            "title": "Premier job",
-            "author": "CaenCamp"
-        }
-    ]
-}

--- a/apps/api-mocked/db/job.js
+++ b/apps/api-mocked/db/job.js
@@ -6,7 +6,7 @@ module.exports = {
     fake: (id, organization) => ({
         '@context': 'http://schema.org',
         '@type': 'JobPosting',
-        '@id': '/offers/' + id,
+        '@id': '/jobs/' + id,
         id: id,
         title: faker.lorem.words(3),
         hiringOrganization: {

--- a/apps/api-mocked/db/offer.js
+++ b/apps/api-mocked/db/offer.js
@@ -1,0 +1,18 @@
+const faker = require('faker');
+
+faker.locale = 'fr';
+
+module.exports = {
+    fake: (id, organization) => ({
+        '@context': 'http://schema.org',
+        '@type': 'JobPosting',
+        '@id': '/offers/' + id,
+        id: id,
+        title: faker.lorem.words(3),
+        hiringOrganization: {
+            '@type': 'Organization',
+            '@id': '/organizations/' + organization.id,
+            name: organization.name
+        }
+    })
+};

--- a/apps/api-mocked/db/organization.js
+++ b/apps/api-mocked/db/organization.js
@@ -1,0 +1,38 @@
+const faker = require('faker');
+
+faker.locale = 'fr';
+
+module.exports = {
+    fake: id => ({
+        '@context': 'http://schema.org',
+        '@type': 'Organization',
+        '@id': '/organizations/' + id,
+        id: id,
+        name: faker.company.companyName(),
+        description: faker.lorem.sentence(),
+        image: {
+            '@type': 'ImageObject',
+            caption: 'Logo',
+            contentUrl: faker.image.imageUrl(300, 200),
+            width: 300,
+            height: 200
+        },
+        url: faker.internet.url(),
+        email: faker.internet.email(),
+        address: {
+            '@type': 'PostalAddress',
+            streetAddress: faker.address.streetAddress(),
+            postalCode: faker.address.postalCode,
+            addressLocality:
+                faker.address.city() + ', ' + faker.address.country()
+        },
+        offers: []
+    }),
+    addOffer: (organization, offer) => {
+        organization.offers.push({
+            '@type': 'JobPosting',
+            '@id': '/offers/' + offer.id,
+            title: offer.title
+        });
+    }
+};

--- a/apps/api-mocked/db/organization.js
+++ b/apps/api-mocked/db/organization.js
@@ -26,13 +26,13 @@ module.exports = {
             addressLocality:
                 faker.address.city() + ', ' + faker.address.country()
         },
-        offers: []
+        jobs: []
     }),
-    addOffer: (organization, offer) => {
-        organization.offers.push({
+    addJobs: (organization, job) => {
+        organization.jobs.push({
             '@type': 'JobPosting',
-            '@id': '/offers/' + offer.id,
-            title: offer.title
+            '@id': '/jobs/' + job.id,
+            title: job.title
         });
     }
 };

--- a/apps/api-mocked/index.js
+++ b/apps/api-mocked/index.js
@@ -1,0 +1,21 @@
+const organization = require('./db/organization');
+const offer = require('./db/offer');
+
+module.exports = () => {
+    const data = { organizations: [], offers: [] };
+
+    for (let i = 0; i < 10; i++) {
+        const fakeOrganization = organization.fake(i);
+
+        for (let j = 0; j < 3; j++) {
+            const fakeOffer = offer.fake(j, fakeOrganization);
+            data.offers.push(fakeOffer);
+
+            organization.addOffer(fakeOrganization, fakeOffer);
+        }
+
+        data.organizations.push(fakeOrganization);
+    }
+
+    return data;
+};

--- a/apps/api-mocked/index.js
+++ b/apps/api-mocked/index.js
@@ -1,5 +1,5 @@
 const organization = require('./db/organization');
-const offer = require('./db/offer');
+const job = require('./db/job');
 
 module.exports = () => {
     const data = { organizations: [], offers: [] };
@@ -8,10 +8,10 @@ module.exports = () => {
         const fakeOrganization = organization.fake(i);
 
         for (let j = 0; j < 3; j++) {
-            const fakeOffer = offer.fake(j, fakeOrganization);
-            data.offers.push(fakeOffer);
+            const fakeJob = job.fake(j, fakeOrganization);
+            data.jobs.push(fakeJob);
 
-            organization.addOffer(fakeOrganization, fakeOffer);
+            organization.addJob(fakeOrganization, fakeJob);
         }
 
         data.organizations.push(fakeOrganization);

--- a/apps/api-mocked/package.json
+++ b/apps/api-mocked/package.json
@@ -4,9 +4,12 @@
     "description": "Mocked backend part of the caencamp jobboard",
     "author": "Alexis Janvier <contact@alexisjanvier.net>",
     "scripts": {
-        "start": "json-server --host 0.0.0.0 --watch db.json"
+        "start": "json-server --host 0.0.0.0 --watch index.js"
     },
     "dependencies": {
         "json-server": "0.15.1"
+    },
+    "devDependencies": {
+        "faker": "4.1.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3112,7 +3112,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@^4.1.0:
+faker@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
   integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3112,6 +3112,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
+  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"


### PR DESCRIPTION
## Description

Le but de cette fonctionnalité est de fournir le modèle sous forme d'objets json. Il a été convenu d'utiliser les schemas de schema.org pour définir les différentes entités.

http://schema.org/Organization
http://schema.org/JobPosting

## Issue associée

Cette demande de fustion couvre l'[issue 10](https://github.com/CaenCamp/jobs-caen-camp/issues/10) .

## Tâches 

- [*x*] Définition des différents modèles depuis schema.org.
- [*x*] Factories api-mocked avec la librairie Faker.


