### PR TITLE
Ajout d'un serveur de mock reposant sur le contrat OpenAPI [Follow #25]

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -17,6 +17,10 @@
   },
   "servers": [
     {
+      "url": "http://localhost:8004",
+      "description": "Mock server with Prism"
+    },
+    {
       "url": "http://localhost:8001",
       "description": "Local server"
     }

--- a/apps/api/openapi/openapi.yaml
+++ b/apps/api/openapi/openapi.yaml
@@ -12,6 +12,8 @@ info:
     name: GNU GPLv3
     url: 'https://github.com/CaenCamp/jobs-caen-camp/blob/master/LICENSE'
 servers:
+  - url: 'http://localhost:8004'
+    description: Mock server with Prism
   - url: 'http://localhost:8001'
     description: Local server
 security: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,11 @@ services:
       - SWAGGER_JSON=/openapi/openapi.json
     ports:
       - 8003:8080
+
+  prism:
+    image: stoplight/prism:3
+    volumes:
+      - ./apps/api/openapi:/openapi
+    ports:
+      - 8004:4010
+    command: mock -d -h 0.0.0.0 "/openapi/openapi.json"


### PR DESCRIPTION
# Description

Suivant la mise en place du contrat OpenAPI dans le PR #25 , cette PR ajoute le serveur de mock [Prism](https://stoplight.io/open-source/prism) à la stack de développement.

![Capture d’écran de 2020-03-04 12-48-06](https://user-images.githubusercontent.com/547706/75876962-f0c5ae80-5e16-11ea-880a-6609af72ab62.png)

![Capture d’écran de 2020-03-04 12-44-23](https://user-images.githubusercontent.com/547706/75876970-f3c09f00-5e16-11ea-933b-4a5877b383a5.png)

