### PR TITLE
Mise à jour des dépendances

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,7 +36,7 @@
         "signale": "1.4.0"
     },
     "devDependencies": {
-        "@stoplight/spectral": "5.1.0",
+        "@stoplight/spectral": "5.2.0",
         "knex": "0.20.11",
         "pg": "7.18.2"
     }

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "axios": "0.19.2",
-        "svelte": "3.19.2",
-        "svelte-routing": "1.4.1"
+        "svelte": "3.20.1",
+        "svelte-routing": "1.4.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
         "prettier-plugin-svelte": "0.7.0",
         "serve": "11.3.0",
         "style-loader": "1.1.3",
-        "svelte": "3.19.2",
+        "svelte": "3.20.1",
         "svelte-jester": "1.0.5",
         "svelte-loader": "2.13.6",
-        "swagger-cli": "3.0.1",
+        "swagger-cli": "4.0.2",
         "webpack": "4.42.0",
         "webpack-cli": "3.3.11",
         "webpack-dev-server": "3.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,48 @@
 # yarn lockfile v1
 
 
+"@apidevtools/json-schema-ref-parser@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz#9eb749499b3f8d919e90bb141e4b6f67aee4692d"
+  integrity sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.0"
+    call-me-maybe "^1.0.1"
+    js-yaml "^3.13.1"
+
+"@apidevtools/openapi-schemas@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.3.tgz#c21f198b445bc8b8a90cd4f97534b96deefdfcb4"
+  integrity sha512-QoPaxGXfgqgGpK1p21FJ400z56hV681a8DOcZt3J5z0WIHgFeaIZ4+6bX5ATqmOoCpRCsH4ITEwKaOyFMz7wOA==
+
+"@apidevtools/swagger-cli@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-cli/-/swagger-cli-4.0.2.tgz#35688c980ea52362ddddefcf59436fff1832fe16"
+  integrity sha512-f2u+J7QlPySpMlB/jG522/8lKFXxeYt4ygd4FXZlidGrZsTE4Dbc5Hor4zO8vvM5QjrACvpN3zDnKIpb8QVR1g==
+  dependencies:
+    "@apidevtools/swagger-parser" "^9.0.1"
+    chalk "^3.0.0"
+    js-yaml "^3.13.1"
+    yargs "^15.3.1"
+
+"@apidevtools/swagger-methods@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-methods/-/swagger-methods-3.0.1.tgz#cf3b1c6b92f811d3f14d51645d277fb54ddd5211"
+  integrity sha512-1Vlm18XYW6Yg7uHunroXeunWz5FShPFAdxBbPy8H6niB2Elz9QQsCoYHMbcc11EL1pTxaIr9HXz2An/mHXlX1Q==
+
+"@apidevtools/swagger-parser@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-parser/-/swagger-parser-9.0.1.tgz#592e39dc412452ac4b34507a765e4d74ff6eda14"
+  integrity sha512-Irqybg4dQrcHhZcxJc/UM4vO7Ksoj1Id5e+K94XUOzllqX1n47HEA50EKiXTCQbykxuJ4cYGIivjx/MRSTC5OA==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^8.0.0"
+    "@apidevtools/openapi-schemas" "^2.0.2"
+    "@apidevtools/swagger-methods" "^3.0.0"
+    "@jsdevtools/ono" "^7.1.0"
+    call-me-maybe "^1.0.1"
+    openapi-types "^1.3.5"
+    z-schema "^4.2.2"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -1076,6 +1118,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jsdevtools/ono@^7.1.0":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.1.tgz#36034f9cb0fb456858c137a3f3e6d6db67ab5cc5"
+  integrity sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A==
+
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@marionebl/sander/-/sander-0.6.1.tgz#1958965874f24bc51be48875feb50d642fc41f7b"
@@ -1153,10 +1200,20 @@
     tslib "^1.10.0"
     urijs "~1.19.1"
 
-"@stoplight/json@^3.1.2", "@stoplight/json@^3.4.0":
+"@stoplight/json@^3.1.2":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.5.1.tgz#afc6ffcbe2ada8f9b16680fd7885688cf9beec7e"
   integrity sha512-O5WUW2yfAvtrqeq60YrbxpTvk87Ti2IeJ5oVa2XNJ2s+IIxx0CM+j316QoOjSGs+twrRpwb3jT9CFPrq7Ghkzg==
+  dependencies:
+    "@stoplight/types" "^11.4.0"
+    jsonc-parser "~2.2.0"
+    lodash "^4.17.15"
+    safe-stable-stringify "^1.1"
+
+"@stoplight/json@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.6.0.tgz#51ab4c677ec5aadcffd5c6ed67b6dbf51a5f93ba"
+  integrity sha512-6hJN735r+aPzHP28HnBj30uC+RGyf/ZWEtAMlrXI4DntzocWvhgDqxLuLgOlmXkMd/4OAlD7fJQ/cI2RXNuWvQ==
   dependencies:
     "@stoplight/types" "^11.4.0"
     jsonc-parser "~2.2.0"
@@ -1168,17 +1225,17 @@
   resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.3.1.tgz#1246c983279af20dcfb806d138add9f81cb1efd2"
   integrity sha512-I6YEfxspGglxt7MbgNbKThHdqh8CJWnDC1x1JUk2rka2D7mCpMSEu5I8IiAp997Dp4YIXDY6Did6gge8OY8KnA==
 
-"@stoplight/spectral@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.1.0.tgz#1abb3b377f9e17e10950da0e69e4a5acc63042eb"
-  integrity sha512-Uwm5ZGE5dqsc6lsAMAnA2VKOHw7ey77SLluu52hyCBPfYZN/WmPfO6AaWbM38cR84TnuDnvvwoOjRzLWDOCdBA==
+"@stoplight/spectral@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.2.0.tgz#95eb3faeca34f3c84610d37c276a90b1c44ce843"
+  integrity sha512-2cWDhst+P+KE2tGnu3+r/uCi+njrvcK31auUvuhX/JEmC/F+NYV6hcYqsFTszuHRT2lGvF+S/a1s+2Xu/7qylA==
   dependencies:
-    "@stoplight/json" "^3.4.0"
+    "@stoplight/json" "^3.6.0"
     "@stoplight/json-ref-readers" "^1.1.1"
     "@stoplight/json-ref-resolver" "^3.0.6"
     "@stoplight/path" "^1.3.0"
     "@stoplight/types" "^11.2.0"
-    "@stoplight/yaml" "^3.5.0"
+    "@stoplight/yaml" "^3.7.0"
     abort-controller "^3.0.0"
     ajv "^6.10"
     ajv-oai "^1.1.5"
@@ -1209,10 +1266,10 @@
   resolved "https://registry.yarnpkg.com/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.44.tgz#ed3c962564283e9983f7895a6effc3994286df5e"
   integrity sha512-PdY8p2Ufgtorf4d2DbKMfknILMa8KwuyyMMR/2lgK1mLaU8F5PKWYc+h9hIzC+ar0bh7m9h2rINo32m7ADfVyA==
 
-"@stoplight/yaml@^3.5.0":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/yaml/-/yaml-3.5.2.tgz#6674341ecf08c0024988f6b83d0a6f7a73bfbef1"
-  integrity sha512-hTxAvQeHn87XgxUVi7BFzIrvBANy/Q2A3O6PHmrzqOTbGoN7p7J3kRliiV35ZPOg/6q50QttMYO3BGFyemRLlw==
+"@stoplight/yaml@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/yaml/-/yaml-3.7.0.tgz#76cb3a0b7f9344eb7c7f2eefde175bc9b391040c"
+  integrity sha512-lYs577C0tqs3WHtused0hclE+YHVshgeZT8i6kkqSIt1GUP3Hbe4AwZDEvFgZ9+9pa0JGlmKMrm0PJfvfKFxkw==
   dependencies:
     "@stoplight/types" "^11.1.1"
     "@stoplight/yaml-ast-parser" "0.0.44"
@@ -6403,15 +6460,6 @@ json-parse-helpfulerror@^1.0.3:
   dependencies:
     jju "^1.1.0"
 
-json-schema-ref-parser@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz#abb3f2613911e9060dc2268477b40591753facf0"
-  integrity sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    js-yaml "^3.13.1"
-    ono "^6.0.0"
-
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -7833,16 +7881,6 @@ only@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
   integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
-
-ono@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ono/-/ono-6.0.1.tgz#1bc14ffb8af1e5db3f7397f75b88e4a2d64bbd71"
-  integrity sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA==
-
-openapi-schemas@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/openapi-schemas/-/openapi-schemas-1.0.3.tgz#0fa2f19e44ce8a1cdab9c9f616df4babe1aa026b"
-  integrity sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ==
 
 openapi-types@^1.3.5:
   version "1.3.5"
@@ -10128,43 +10166,22 @@ svelte-loader@2.13.6:
     loader-utils "^1.1.0"
     svelte-dev-helper "^1.1.9"
 
-svelte-routing@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/svelte-routing/-/svelte-routing-1.4.1.tgz#bf7af5a56e72932e531441c17059b9a1bc48e240"
-  integrity sha512-8XZOV2lSjpXIPS3e4UbvjOj5YAHuf+GzTR/0TVjrLQLABiImGlC3pNa1Qj7glug4WXWP0xORZbsFiRLCiiQF4A==
+svelte-routing@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/svelte-routing/-/svelte-routing-1.4.2.tgz#291160b537c9c73e711731eb099c48bb24cc3419"
+  integrity sha512-CSCKRLeOp9vjsDGGOEgL9DPm9HZLgZuTNehyTCl3K+6fCVH1Aw/K/WicavAVNcbsHmdR4wgF//0YVR9hrcdvGA==
 
-svelte@3.19.2:
-  version "3.19.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.19.2.tgz#4b0169ee33b37399f08eb92163593a0a46c242c7"
-  integrity sha512-Jswg065u8R9QYcN0rdpTQSFIr0hFq7YUzcPpEY6ZpFSAWkJKZG9AJvHE1d8+NJDTfr7SzKrO6EYssYYkUmszpA==
+svelte@3.20.1:
+  version "3.20.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.20.1.tgz#8417fcd883a2f534b642a0737368272e651cf3ac"
+  integrity sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q==
 
-swagger-cli@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/swagger-cli/-/swagger-cli-3.0.1.tgz#ed49c5844e9c10d1fd97d8501611846356ca48ed"
-  integrity sha512-RkCH3ylYmtNj5cIQCQtP+f01mTcwkGEKXsnIN+Vyiqf8M0SdgPfyjuNJ78hj47xGXCDysCBINQHtP0p8phYSBA==
+swagger-cli@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/swagger-cli/-/swagger-cli-4.0.2.tgz#cf27a7f25158c2216b4be95a6af9d6c969340dfc"
+  integrity sha512-XzKVHMDGlmiK+dgTxRSX7SSbG5KDsU4RS9eX3VSBw6ZPfW1aWYAbo2FuhArnsFMiz4/0KXJ8D/Lkii7xeSXviw==
   dependencies:
-    chalk "^3.0.0"
-    js-yaml "^3.13.1"
-    swagger-parser "^8.0.4"
-    yargs "^15.1.0"
-
-swagger-methods@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/swagger-methods/-/swagger-methods-2.0.2.tgz#5891d5536e54d5ba8e7ae1007acc9170f41c9590"
-  integrity sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg==
-
-swagger-parser@^8.0.4:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/swagger-parser/-/swagger-parser-8.0.4.tgz#ddec68723d13ee3748dd08fd5b7ba579327595da"
-  integrity sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    json-schema-ref-parser "^7.1.3"
-    ono "^6.0.0"
-    openapi-schemas "^1.0.2"
-    openapi-types "^1.3.5"
-    swagger-methods "^2.0.1"
-    z-schema "^4.2.2"
+    "@apidevtools/swagger-cli" "4.0.2"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -11281,6 +11298,14 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
@@ -11332,6 +11357,23 @@ yargs@^15.0.0, yargs@^15.0.2, yargs@^15.1.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^16.1.0"
+
+yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yauzl@2.10.0:
   version "2.10.0"


### PR DESCRIPTION
faille de sécurité remontée sur Github. Mais je ne suis pas certain que cela fixe le problème lié à minimist ... Et c'est "balo", mais il n'y a pas de `audit fix` avec Yarn :( Du coup, comme nous sommes encore avec du code qui n'est pas en production, je propose d'attendre l'upgrade du package responsable si cette mise à jours ne fixe pas le problème.

# Description

![Capture d’écran de 2020-03-19 08-17-17](https://user-images.githubusercontent.com/547706/77041397-20012180-69ba-11ea-917d-33cc2d6e042e.png)

https://github.com/CaenCamp/jobs-caen-camp/network/alert/yarn.lock/minimist/open

![Capture d’écran de 2020-03-19 08-29-47](https://user-images.githubusercontent.com/547706/77042370-daddef00-69bb-11ea-9520-0fc967e05df1.png)

