### PR TITLE
Réparation du make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,11 @@ install: ## Install all js deps
 	@cp -n ./config/development.dist ./config/development.env
 	@${DC_DEV} run --rm --no-deps api bash -ci '\
 		cd ../../ && \
-		yarn \
+		yarn && \
+        cd not-in-yarn-workspace/admin && \
+        npm install \
 	'
+
 install-cypress: ## Install cypress.io bin on local environment, not in Docker !
 	@node_modules/.bin/cypress install
 


### PR DESCRIPTION
# Description

La recette `install` du makefile ne lance pas l'installation des dépendances de l'administration, qui n'est pas déclarée au sein du yarn workspace

# Related Issue

#42 
