### PR TITLE
Use shell command instead of native cp to fix issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help: ## Display available commands
 # =====================================================================
 
 install: ## Install all js deps
-	@cp -n ./config/development.dist ./config/development.env
+	$(shell cp -n ./config/development.dist ./config/development.env)
 	@${DC_DEV} run --rm --no-deps api bash -ci '\
 		cd ../../ && \
 		yarn \


### PR DESCRIPTION
# Description

J'ai clone le projet et quand j'ai lancé `make install` j'ai eu une erreur 
```
❯ make install
make: *** [install] Error 1
```

Le CP, pour une raison que j'ignore, ne fonctionnait pas.
Comme je suis pas super calé en makefile mais google l'est beaucoup plus que moi, j'ai googlé et je suis tombé sur un dev affirmant que c'était mieux d'utiliser la commande shell.

Je ne sais pas si c'est une bonne idée mais en changeant cela dans le make file, et bien ça a fonctionné.

