### PR TITLE
Parametres de tri et de pagination en string dans le contat OpeanAPI

### DIFF
--- a/apps/api/openapi/openapi.yaml
+++ b/apps/api/openapi/openapi.yaml
@@ -1062,25 +1062,17 @@ components:
       in: query
       description: "Le tri applicable à la liste. C'est un tableau stringifié de la forme [sortProp, sortDirection]"
       required: false
-      explode: false
+      explode: true
       schema:
-        type: array
-        maxItems: 2
-        minItems: 2
-        items:
-          type: string
+        type: string
     Pagination:
       name: pagination
       in: query
       description: "Les paramètres pour la pagination. C'est un tableau stringifié de la forme [perPage, currentPage]"
       required: false
-      explode: false
+      explode: true
       schema:
-        type: array
-        maxItems: 2
-        minItems: 2
-        items:
-          type: string
+        type: string
     UUID:
       name: identifier
       in: path


### PR DESCRIPTION
# Description

L'administration envoie les paramètre de requête de tri et de pagination en string. C'est d'ailleur ce qu'attend l'API. Mais le contrat Open Api décrit ces deux paramètres comme des tableau de string. D'ou cette erreur: 

![bugSortPagination](https://user-images.githubusercontent.com/547706/78420832-2d253e00-7653-11ea-87a3-5713da48eab1.gif)

