### PR TITLE
Refactor api pagination

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,8 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "jamesbirtles.svelte-vscode",
-        "orta.vscode-jest"
+        "orta.vscode-jest",
+        "42crunch.vscode-openapi"
     ],
     "unwantedRecommendations": ["hookyqr.beautify"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "editor.codeActionsOnSave": {
         "source.fixAll": true
     },
-    "cSpell.enabled": true
+    "cSpell.enabled": true,
+    "editor.rulers": [80]
 }

--- a/apps/api/openapi/openapi.yaml
+++ b/apps/api/openapi/openapi.yaml
@@ -87,7 +87,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/ExtendedErrorModel'
       operationId: getJobPostings
-      description: "Obtenir une liste paginée d'offres d'emploi\n\nCette liste est filtrable par filters={ key: value, key2: value ...} :\n* title\n* skills\n* employmentType\n* datePosted_before\n* datePosted_after\n* jobStartDate_before\n* jobStartDate_after\n* validThrough_before\n* validThrough_after\n* hiringOrganizationName\n* hiringOrganizationPostalCode\n* hiringOrganizationAddressLocality\n* hiringOrganizationAddressCountry\n\nCette liste est triable par sort=[key, sortDirection_ASC_DESC] : \n* datePosted\n* title\n* jobStartDate\n* validThrough\n* hiringOrganizationName\n* hiringOrganizationIdentifier\n* hiringOrganizationPostalCode\n* hiringOrganizationAddressLocality\n* hiringOrganizationAddressCountry\n\nLa pagination est controlable via le paramètre de requête pagination=[nombreDeRésultatsParPage, numeroDePage]"
+      description: |
+        Obtenir une liste paginée d'offres d'emploi
+
+        Cette liste est filtrable par filters={ key: value, key2: value ...} :
+        * title
+        * skills
+        * employmentType
+        * datePosted_before
+        * datePosted_after
+        * jobStartDate_before
+        * jobStartDate_after
+        * validThrough_before
+        * validThrough_after
+        * hiringOrganizationName
+        * hiringOrganizationPostalCode
+        * hiringOrganizationAddressLocality
+        * hiringOrganizationAddressCountry
+
+        Cette liste est triable par sort=[key, sortDirection_ASC_DESC] :
+        * datePosted
+        * title
+        * jobStartDate
+        * validThrough
+        * hiringOrganizationName
+        * hiringOrganizationIdentifier
+        * hiringOrganizationPostalCode
+        * hiringOrganizationAddressLocality
+        * hiringOrganizationAddressCountry
       parameters:
         - $ref: '#/components/parameters/Sort'
         - $ref: '#/components/parameters/Filter'
@@ -439,7 +466,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ExtendedErrorModel'
       operationId: getOrganizations
-      description: "Obtenir la liste des entreprises.\n\nCette liste est filtrable par filters={ key: value, key2: value ...} :\n* name\n* address_locality\n* postal_code\n\nCette liste est triable par sort=[key, sortDirection_ASC_DESC] : \n* name\n* address_locality\n* postal_code\n\nLa pagination est controlable via le paramètre de requête pagination=[nombreDeRésultatsParPage, numeroDePage]"
+      description: |
+        Obtenir la liste des entreprises.\n\nCette liste est filtrable par filters={ key: value, key2: value ...} :
+        * name
+        * address_locality
+        * postal_code
+
+        Cette liste est triable par sort=[key, sortDirection_ASC_DESC] :
+        * name
+        * address_locality
+        * postal_code
       parameters:
         - $ref: '#/components/parameters/Filter'
         - $ref: '#/components/parameters/Sort'

--- a/apps/api/openapi/openapi.yaml
+++ b/apps/api/openapi/openapi.yaml
@@ -58,11 +58,10 @@ paths:
                           addressLocality: Caen
                           postalCode: '14000'
           headers:
-            content-range:
-              schema:
-                type: string
-              description: "Return information about pagination, with form 'objectType from-to/total'"
-              required: true
+            X-Total-Count:
+                $ref: '#/components/headers/X-Total-Count'
+            Link:
+                $ref: '#/components/headers/Link'
         '400':
           description: Bad Request
           content:
@@ -411,11 +410,10 @@ paths:
                           name: 'John Do, CTO'
                           contactType: "Offres d'emploi"
           headers:
-            content-range:
-              schema:
-                type: string
-              required: true
-              description: "Return information about pagination, with form 'objectType from-to/total'"
+            X-Total-Count:
+                $ref: '#/components/headers/X-Total-Count'
+            Link:
+                $ref: '#/components/headers/Link'
         '400':
           description: Bad Request
           content:
@@ -715,6 +713,24 @@ paths:
         - Entreprises
 components:
   securitySchemes: {}
+  headers:
+    X-Total-Count:
+        description: "Return information about total items to paginate"
+        schema:
+            type: integer
+        example: 42
+        required: false
+    Link:
+        description: "Return information about pagination actions"
+        schema:
+            type: string
+        example: |
+            </resources?currentPage=3&perPage=10>; rel="self",
+            </resources?currentPage=1&perPage=10>; rel="first",
+            </resources?currentPage=2&perPage=10>; rel="prev",
+            </resources?currentPage=4&perPage=10>; rel="next",
+            </resources?currentPage=5&perPage=10>; rel="last",
+        required: false
   schemas:
     JobPosting:
       description: "Une offre d'emploi"

--- a/apps/api/openapi/openapi.yaml
+++ b/apps/api/openapi/openapi.yaml
@@ -92,7 +92,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Sort'
         - $ref: '#/components/parameters/Filter'
-        - $ref: '#/components/parameters/Pagination'
+        - $ref: '#/components/parameters/PaginationCurrentPage'
+        - $ref: '#/components/parameters/PaginationPerPage'
     post:
       tags:
         - "Offres d'emploi"
@@ -444,7 +445,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Filter'
         - $ref: '#/components/parameters/Sort'
-        - $ref: '#/components/parameters/Pagination'
+        - $ref: '#/components/parameters/PaginationCurrentPage'
+        - $ref: '#/components/parameters/PaginationPerPage'
     post:
       summary: "Création d'une entreprise"
       operationId: createOrganization
@@ -1069,18 +1071,22 @@ components:
         minItems: 2
         items:
           type: string
-    Pagination:
-      name: pagination
+    PaginationCurrentPage:
+      name: currentPage
       in: query
-      description: "Les paramètres pour la pagination. C'est un tableau stringifié de la forme [perPage, currentPage]"
+      description: "Le paramètre de pagination pour définir la page courrante."
       required: false
-      explode: false
       schema:
-        type: array
-        maxItems: 2
-        minItems: 2
-        items:
-          type: string
+        type: integer
+        example: 1
+    PaginationPerPage:
+      name: perPage
+      in: query
+      description: "Le paramètre de pagination pour définir le nombre d'éléments par page."
+      required: false
+      schema:
+        type: integer
+        example: 10
     UUID:
       name: identifier
       in: path

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,8 +10,8 @@
         "url": "git+https://github.com/CaenCamp/jobs-caen-camp.git"
     },
     "scripts": {
-        "dev": "nodemon --watch src --watch openapi src/index.js",
-        "start": "nodemon --watch src --watch openapi src/index.js",
+        "dev": "nodemon --watch src --watch openapi src/index.js --ext js,json,yml",
+        "start": "nodemon --watch src --watch openapi src/index.js --ext js,json,yml",
         "openapi:check": "spectral lint ./openapi/openapi.yaml",
         "test": "jest",
         "test:watch": "jest --watchAll",

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -17,7 +17,7 @@ app.use(
     cors({
         origin: '*',
         allowHeaders: ['Origin, Content-Type, Accept'],
-        exposeHeaders: ['Content-Range'],
+        exposeHeaders: ['X-Total-Count', 'Link'],
     })
 );
 

--- a/apps/api/src/job-posting/repository.js
+++ b/apps/api/src/job-posting/repository.js
@@ -108,7 +108,7 @@ const getFilteredJobPostingsQuery = (client, filters, sort) => {
         );
     }
 
-    Object.keys(restFiltersThatMustBeDates).map(key => {
+    Object.keys(restFiltersThatMustBeDates).map((key) => {
         try {
             const queryDate = new Date(restFiltersThatMustBeDates[key]);
             const [what, when] = key.split('_');
@@ -137,7 +137,7 @@ const getFilteredJobPostingsQuery = (client, filters, sort) => {
  * @param {object} dbOrganization - organization data from database
  * @returns {object} an organization object as describe in OpenAPI contract
  */
-const formatJobPostingForAPI = dbJobPosting => {
+const formatJobPostingForAPI = (dbJobPosting) => {
     return dbJobPosting
         ? {
               ...omit(dbJobPosting, [
@@ -199,8 +199,9 @@ const getJobPostingPaginatedList = async ({
 
     return query
         .paginate({ perPage, currentPage, isLengthAware: true })
-        .then(result => ({
+        .then((result) => ({
             jobPostings: result.data.map(formatJobPostingForAPI),
+            pagination: result.pagination,
         }));
 };
 
@@ -239,7 +240,7 @@ const getJobPostingByIdQuery = (client, jobPostingId) => {
 const getJobPosting = async ({ client, jobPostingId }) => {
     return getJobPostingByIdQuery(client, jobPostingId)
         .then(formatJobPostingForAPI)
-        .catch(error => ({ error }));
+        .catch((error) => ({ error }));
 };
 
 /**
@@ -267,7 +268,7 @@ const createJobPosting = async ({ client, apiData }) => {
                 formatJobPostingForAPI
             );
         })
-        .catch(error => ({ error }));
+        .catch((error) => ({ error }));
 };
 
 /**
@@ -281,10 +282,10 @@ const deleteJobPosting = async ({ client, jobPostingId }) => {
     return client('job_posting')
         .where({ id: jobPostingId })
         .del()
-        .then(nbDeletion => {
+        .then((nbDeletion) => {
             return nbDeletion ? { id: jobPostingId } : {};
         })
-        .catch(error => ({ error }));
+        .catch((error) => ({ error }));
 };
 
 /**
@@ -325,7 +326,7 @@ const updateJobPosting = async ({ client, jobPostingId, apiData }) => {
     const updatedJobPosting = await client('job_posting')
         .where({ id: jobPostingId })
         .update(apiData)
-        .catch(error => ({ error }));
+        .catch((error) => ({ error }));
     if (updatedJobPosting.error) {
         return updatedJobPosting;
     }
@@ -333,7 +334,7 @@ const updateJobPosting = async ({ client, jobPostingId, apiData }) => {
     // return the complete jobPosting from db
     return getJobPostingByIdQuery(client, jobPostingId)
         .then(formatJobPostingForAPI)
-        .catch(error => ({ error }));
+        .catch((error) => ({ error }));
 };
 
 module.exports = {

--- a/apps/api/src/job-posting/repository.js
+++ b/apps/api/src/job-posting/repository.js
@@ -182,7 +182,7 @@ const formatJobPostingForAPI = dbJobPosting => {
  * @param {object} client - The Database client
  * @param {object} filters - JobPosting Filters
  * @param {Array} sort - Sort parameters [columnName, direction]
- * @param {Array} pagination - Pagination [perPage, currentPage]
+ * @param {object} pagination - Pagination {perPage: 10, currentPage: 1}
  * @returns {Promise} - paginated object with paginated jobPosting list and totalCount
  */
 const getJobPostingPaginatedList = async ({

--- a/apps/api/src/job-posting/repository.js
+++ b/apps/api/src/job-posting/repository.js
@@ -3,7 +3,6 @@ const signale = require('signale');
 
 const {
     filtersSanitizer,
-    formatPaginationContentRange,
     paginationSanitizer,
     sortSanitizer,
 } = require('../toolbox/sanitizers');
@@ -202,10 +201,6 @@ const getJobPostingPaginatedList = async ({
         .paginate({ perPage, currentPage, isLengthAware: true })
         .then(result => ({
             jobPostings: result.data.map(formatJobPostingForAPI),
-            contentRange: formatPaginationContentRange(
-                'jobPostings',
-                result.pagination
-            ),
         }));
 };
 

--- a/apps/api/src/job-posting/router.js
+++ b/apps/api/src/job-posting/router.js
@@ -14,7 +14,7 @@ const router = new Router({
 });
 
 router.get('/', async ctx => {
-    const { jobPostings, contentRange } = await getJobPostingPaginatedList({
+    const { jobPostings } = await getJobPostingPaginatedList({
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
         sort: parseJsonQueryParameter(ctx.query.sort),
@@ -24,7 +24,10 @@ router.get('/', async ctx => {
         },
     });
 
-    ctx.set('Content-Range', contentRange);
+    // ToDo: Add X-Total-Count Header
+    ctx.set('X-Total-Count', 0);
+    // ToDo: Add Link Header
+    ctx.set('Link', 'TODO');
     ctx.body = jobPostings;
 });
 

--- a/apps/api/src/job-posting/router.js
+++ b/apps/api/src/job-posting/router.js
@@ -18,7 +18,10 @@ router.get('/', async ctx => {
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
         sort: parseJsonQueryParameter(ctx.query.sort),
-        pagination: parseJsonQueryParameter(ctx.query.pagination),
+        pagination: {
+            currentPage: ctx.query.currentPage,
+            perPage: ctx.query.perPage,
+        },
     });
 
     ctx.set('Content-Range', contentRange);

--- a/apps/api/src/organization/repository.js
+++ b/apps/api/src/organization/repository.js
@@ -97,7 +97,7 @@ const formatOrganizationForAPI = dbOrganization => ({
  * @param {object} client - The Database client
  * @param {object} filters - Organization Filter
  * @param {Array} sort - Sort parameters [columnName, direction]
- * @param {Array} pagination - Pagination [perPage, currentPage]
+ * @param {object} pagination - Pagination {perPage: 10, currentPage: 1}
  * @returns {Promise} - paginated object with paginated organization list and totalCount
  */
 const getOrganizationPaginatedList = async ({

--- a/apps/api/src/organization/repository.js
+++ b/apps/api/src/organization/repository.js
@@ -117,10 +117,6 @@ const getOrganizationPaginatedList = async ({
         .paginate({ perPage, currentPage, isLengthAware: true })
         .then(result => ({
             organizations: result.data.map(formatOrganizationForAPI),
-            contentRange: formatPaginationContentRange(
-                'organizations',
-                result.pagination
-            ),
         }));
 };
 

--- a/apps/api/src/organization/router.js
+++ b/apps/api/src/organization/router.js
@@ -28,7 +28,7 @@ router.get('/', async (ctx) => {
     });
 
     const linkHeaderValue = formatPaginationToLinkHeader({
-        resourceURI: '/api/job-postings',
+        resourceURI: '/api/organizations',
         pagination,
     });
 

--- a/apps/api/src/organization/router.js
+++ b/apps/api/src/organization/router.js
@@ -14,7 +14,7 @@ const router = new Router({
 });
 
 router.get('/', async ctx => {
-    const { organizations, contentRange } = await getOrganizationPaginatedList({
+    const { organizations } = await getOrganizationPaginatedList({
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
         sort: parseJsonQueryParameter(ctx.query.sort),
@@ -24,7 +24,10 @@ router.get('/', async ctx => {
         },
     });
 
-    ctx.set('Content-Range', contentRange);
+    // ToDo: Add X-Total-Count Header
+    ctx.set('X-Total-Count', 0);
+    // ToDo: Add Link Header
+    ctx.set('Link', 'TODO');
     ctx.body = organizations;
 });
 

--- a/apps/api/src/organization/router.js
+++ b/apps/api/src/organization/router.js
@@ -7,14 +7,17 @@ const {
     getOrganizationPaginatedList,
     updateOrganization,
 } = require('./repository');
-const { parseJsonQueryParameter } = require('../toolbox/sanitizers');
+const {
+    parseJsonQueryParameter,
+    formatPaginationToLinkHeader,
+} = require('../toolbox/sanitizers');
 
 const router = new Router({
     prefix: '/api/organizations',
 });
 
-router.get('/', async ctx => {
-    const { organizations } = await getOrganizationPaginatedList({
+router.get('/', async (ctx) => {
+    const { organizations, pagination } = await getOrganizationPaginatedList({
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
         sort: parseJsonQueryParameter(ctx.query.sort),
@@ -24,14 +27,19 @@ router.get('/', async ctx => {
         },
     });
 
-    // ToDo: Add X-Total-Count Header
-    ctx.set('X-Total-Count', 0);
-    // ToDo: Add Link Header
-    ctx.set('Link', 'TODO');
+    const linkHeaderValue = formatPaginationToLinkHeader({
+        resourceURI: '/api/job-postings',
+        pagination,
+    });
+
+    ctx.set('X-Total-Count', pagination.total);
+    if (linkHeaderValue) {
+        ctx.set('Link', linkHeaderValue);
+    }
     ctx.body = organizations;
 });
 
-router.post('/', async ctx => {
+router.post('/', async (ctx) => {
     const newOrganization = await createOrganization({
         client: ctx.db,
         apiData: ctx.request.body,
@@ -47,7 +55,7 @@ router.post('/', async ctx => {
     ctx.body = newOrganization;
 });
 
-router.get('/:organizationId', async ctx => {
+router.get('/:organizationId', async (ctx) => {
     const organization = await getOrganization({
         client: ctx.db,
         organizationId: ctx.params.organizationId,
@@ -72,7 +80,7 @@ router.get('/:organizationId', async ctx => {
     ctx.body = organization;
 });
 
-router.delete('/:organizationId', async ctx => {
+router.delete('/:organizationId', async (ctx) => {
     const deletedOrganization = await deleteOrganization({
         client: ctx.db,
         organizationId: ctx.params.organizationId,
@@ -97,7 +105,7 @@ router.delete('/:organizationId', async ctx => {
     ctx.body = deletedOrganization;
 });
 
-router.put('/:organizationId', async ctx => {
+router.put('/:organizationId', async (ctx) => {
     const updatedOrganization = await updateOrganization({
         client: ctx.db,
         organizationId: ctx.params.organizationId,

--- a/apps/api/src/organization/router.js
+++ b/apps/api/src/organization/router.js
@@ -18,7 +18,10 @@ router.get('/', async ctx => {
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
         sort: parseJsonQueryParameter(ctx.query.sort),
-        pagination: parseJsonQueryParameter(ctx.query.pagination),
+        pagination: {
+            currentPage: ctx.query.currentPage,
+            perPage: ctx.query.perPage,
+        },
     });
 
     ctx.set('Content-Range', contentRange);

--- a/apps/api/src/toolbox/sanitizers.js
+++ b/apps/api/src/toolbox/sanitizers.js
@@ -57,20 +57,8 @@ const sortSanitizer = (sort, sortableFields) => {
  * @param {object} pagination - pagination object from query parameters
  * @returns {object} Ready-to-use filters for the sql query
  */
-const paginationSanitizer = pagination => {
-    const sortTwoFirstParameters = [
-        pagination ? parseInt(pagination[0]) || null : null,
-        pagination ? parseInt(pagination[1]) || null : null,
-    ];
-
-    if (
-        !Number.isInteger(sortTwoFirstParameters[0]) ||
-        !Number.isInteger(sortTwoFirstParameters[1])
-    ) {
-        return [10, 1];
-    }
-
-    return sortTwoFirstParameters;
+const paginationSanitizer = ({ perPage, currentPage }) => {
+    return [parseInt(perPage) || 10, parseInt(currentPage) || 1];
 };
 
 /**

--- a/apps/api/src/toolbox/sanitizers.js
+++ b/apps/api/src/toolbox/sanitizers.js
@@ -57,7 +57,7 @@ const sortSanitizer = (sort, sortableFields) => {
  * Function to clean the pagination sent in query parameters
  *
  * @param {object} pagination - pagination object from query parameters
- * @returns {object} Ready-to-use filters for the sql query
+ * @returns {Array} Ready-to-use filters for the sql query
  */
 const paginationSanitizer = ({ perPage, currentPage }) => {
     return [parseInt(perPage) || 10, parseInt(currentPage) || 1];
@@ -80,6 +80,13 @@ const parseJsonQueryParameter = (parameter) => {
     }
 };
 
+/**
+ * Function to return a single pagination information
+ * e.g. </api/job-postings?currentPage=1&perPage=10>; rel="self"
+ *
+ * @param {object}
+ * @returns {String}
+ */
 const linkHeaderItem = ({ resourceURI, currentPage, perPage, rel }) => {
     const params = {
         currentPage,
@@ -88,7 +95,14 @@ const linkHeaderItem = ({ resourceURI, currentPage, perPage, rel }) => {
     return `<${resourceURI}?${querystring.stringify(params)}>; rel="${rel}"`;
 };
 
-const formatPaginationToLinkHeader = ({ resourceURI, pagination }) => {
+/**
+ * Function to return a fill pagination information with
+ * first, prev, self, next and last relations.
+ *
+ * @param {object}
+ * @returns {String}
+ */
+const formatPaginationToLinkHeader = ({ resourceURI, pagination = {} }) => {
     const { currentPage, perPage, lastPage } = pagination;
 
     if (!resourceURI || !currentPage || !perPage || !lastPage) {
@@ -96,7 +110,9 @@ const formatPaginationToLinkHeader = ({ resourceURI, pagination }) => {
     }
 
     const prevPage =
-        currentPage - 1 <= lastPage ? currentPage - 1 : currentPage;
+        currentPage - 1 <= lastPage && currentPage - 1 > 0
+            ? currentPage - 1
+            : currentPage;
     const nextPage =
         currentPage + 1 <= lastPage ? currentPage + 1 : currentPage;
 

--- a/apps/api/src/toolbox/sanitizers.js
+++ b/apps/api/src/toolbox/sanitizers.js
@@ -62,20 +62,6 @@ const paginationSanitizer = ({ perPage, currentPage }) => {
 };
 
 /**
- * Transforms the Knex paging object into a string compatible with the "content-Range" header.
- * https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Content-Range
- *
- * @param {string} objectType - type of object returned in the paginated collection
- * @param {object} pagination - Knex pagination object (https://github.com/felixmosh/knex-paginate#pagination-object)
- * @returns {string} string ready to be set has "Content-Range" http header
- * @example Content-Range: posts 0-24/319
- */
-const formatPaginationContentRange = (objectType, pagination) =>
-    `${objectType.toLowerCase()} ${pagination.from}-${pagination.to}/${
-        pagination.total
-    }`;
-
-/**
  * This method intercepts query parameters expected in JSON but incorrectly formatted.
  *
  * @param {string} parameter - the query parameter expected in JSON
@@ -94,7 +80,6 @@ const parseJsonQueryParameter = parameter => {
 
 module.exports = {
     filtersSanitizer,
-    formatPaginationContentRange,
     paginationSanitizer,
     parseJsonQueryParameter,
     sortSanitizer,

--- a/apps/api/src/toolbox/sanitizers.js
+++ b/apps/api/src/toolbox/sanitizers.js
@@ -82,10 +82,10 @@ const parseJsonQueryParameter = (parameter) => {
 
 /**
  * Function to return a single pagination information
- * e.g. </api/job-postings?currentPage=1&perPage=10>; rel="self"
  *
  * @param {object}
  * @returns {String}
+ * @example </api/job-postings?currentPage=1&perPage=10>; rel="self"
  */
 const linkHeaderItem = ({ resourceURI, currentPage, perPage, rel }) => {
     const params = {

--- a/apps/api/src/toolbox/sanitizers.spec.js
+++ b/apps/api/src/toolbox/sanitizers.spec.js
@@ -132,22 +132,39 @@ describe('Sanitizers', () => {
 
     describe('paginationSanitizer', () => {
         it('should return string pagination params as integer if it possible', () => {
-            expect(paginationSanitizer(['12', '2'])).toEqual([12, 2]);
+            expect(
+                paginationSanitizer({ perPage: '12', currentPage: '2' })
+            ).toEqual([12, 2]);
         });
 
         it('should return default pagination if pagination array is empty', () => {
-            expect(paginationSanitizer([])).toEqual([10, 1]);
+            expect(paginationSanitizer({})).toEqual([10, 1]);
         });
 
         it('should return default pagination if one of pagination params could not be cast as integer', () => {
-            expect(paginationSanitizer(['douze', '2'])).toEqual([10, 1]);
-            expect(paginationSanitizer(['12', 'deux'])).toEqual([10, 1]);
-            expect(paginationSanitizer([{}, '2'])).toEqual([10, 1]);
-            expect(paginationSanitizer([null, '2'])).toEqual([10, 1]);
+            expect(
+                paginationSanitizer({ perPage: 'douze', currentPage: '2' })
+            ).toEqual([10, 1]);
+            expect(
+                paginationSanitizer({ perPage: '12', currentPage: 'deux' })
+            ).toEqual([10, 1]);
+            expect(
+                paginationSanitizer({ perPage: {}, currentPage: '2' })
+            ).toEqual([10, 1]);
+            expect(
+                paginationSanitizer({ perPage: null, currentPage: '2' })
+            ).toEqual([10, 1]);
         });
 
         it('should remove the supernumerary parameters of the pagination array', () => {
-            expect(paginationSanitizer([22, 3, 'foo', 'bar'])).toEqual([22, 3]);
+            expect(
+                paginationSanitizer({
+                    perPage: 22,
+                    currentPage: 3,
+                    notPage: 'foo',
+                    isPage: 'bar',
+                })
+            ).toEqual([22, 3]);
         });
     });
 

--- a/apps/api/src/toolbox/sanitizers.spec.js
+++ b/apps/api/src/toolbox/sanitizers.spec.js
@@ -144,16 +144,16 @@ describe('Sanitizers', () => {
         it('should return default pagination if one of pagination params could not be cast as integer', () => {
             expect(
                 paginationSanitizer({ perPage: 'douze', currentPage: '2' })
-            ).toEqual([10, 1]);
+            ).toEqual([10, 2]);
             expect(
                 paginationSanitizer({ perPage: '12', currentPage: 'deux' })
-            ).toEqual([10, 1]);
+            ).toEqual([12, 1]);
             expect(
                 paginationSanitizer({ perPage: {}, currentPage: '2' })
-            ).toEqual([10, 1]);
+            ).toEqual([10, 2]);
             expect(
                 paginationSanitizer({ perPage: null, currentPage: '2' })
-            ).toEqual([10, 1]);
+            ).toEqual([10, 2]);
         });
 
         it('should remove the supernumerary parameters of the pagination array', () => {

--- a/apps/api/src/toolbox/sanitizers.spec.js
+++ b/apps/api/src/toolbox/sanitizers.spec.js
@@ -180,7 +180,13 @@ describe('Sanitizers', () => {
                     },
                 })
             ).toEqual(
-                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=2&perPage=10>; rel="prev",</api/resources?currentPage=3&perPage=10>; rel="self",</api/resources?currentPage=4&perPage=10>; rel="next",</api/resources?currentPage=5&perPage=10>; rel="last"`
+                [
+                    '</api/resources?currentPage=1&perPage=10>; rel="first"',
+                    '</api/resources?currentPage=2&perPage=10>; rel="prev"',
+                    '</api/resources?currentPage=3&perPage=10>; rel="self"',
+                    '</api/resources?currentPage=4&perPage=10>; rel="next"',
+                    '</api/resources?currentPage=5&perPage=10>; rel="last"',
+                ].join(',')
             );
         });
 
@@ -195,7 +201,13 @@ describe('Sanitizers', () => {
                     },
                 })
             ).toEqual(
-                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=1&perPage=10>; rel="prev",</api/resources?currentPage=1&perPage=10>; rel="self",</api/resources?currentPage=2&perPage=10>; rel="next",</api/resources?currentPage=3&perPage=10>; rel="last"`
+                [
+                    '</api/resources?currentPage=1&perPage=10>; rel="first"',
+                    '</api/resources?currentPage=1&perPage=10>; rel="prev"',
+                    '</api/resources?currentPage=1&perPage=10>; rel="self"',
+                    '</api/resources?currentPage=2&perPage=10>; rel="next"',
+                    '</api/resources?currentPage=3&perPage=10>; rel="last"',
+                ].join(',')
             );
         });
 
@@ -210,7 +222,13 @@ describe('Sanitizers', () => {
                     },
                 })
             ).toEqual(
-                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=2&perPage=10>; rel="prev",</api/resources?currentPage=3&perPage=10>; rel="self",</api/resources?currentPage=3&perPage=10>; rel="next",</api/resources?currentPage=3&perPage=10>; rel="last"`
+                [
+                    '</api/resources?currentPage=1&perPage=10>; rel="first"',
+                    '</api/resources?currentPage=2&perPage=10>; rel="prev"',
+                    '</api/resources?currentPage=3&perPage=10>; rel="self"',
+                    '</api/resources?currentPage=3&perPage=10>; rel="next"',
+                    '</api/resources?currentPage=3&perPage=10>; rel="last"',
+                ].join(',')
             );
         });
 
@@ -225,7 +243,13 @@ describe('Sanitizers', () => {
                     },
                 })
             ).toEqual(
-                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=1&perPage=10>; rel="prev",</api/resources?currentPage=1&perPage=10>; rel="self",</api/resources?currentPage=1&perPage=10>; rel="next",</api/resources?currentPage=1&perPage=10>; rel="last"`
+                [
+                    '</api/resources?currentPage=1&perPage=10>; rel="first"',
+                    '</api/resources?currentPage=1&perPage=10>; rel="prev"',
+                    '</api/resources?currentPage=1&perPage=10>; rel="self"',
+                    '</api/resources?currentPage=1&perPage=10>; rel="next"',
+                    '</api/resources?currentPage=1&perPage=10>; rel="last"',
+                ].join(',')
             );
         });
 

--- a/apps/api/src/toolbox/sanitizers.spec.js
+++ b/apps/api/src/toolbox/sanitizers.spec.js
@@ -1,6 +1,6 @@
 const {
     filtersSanitizer,
-    formatPaginationContentRange,
+    formatPaginationToLinkHeader,
     paginationSanitizer,
     sortSanitizer,
 } = require('./sanitizers');
@@ -165,6 +165,102 @@ describe('Sanitizers', () => {
                     isPage: 'bar',
                 })
             ).toEqual([22, 3]);
+        });
+    });
+
+    describe('formatPaginationToLinkHeader', () => {
+        it('should contain all pagination elements', () => {
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                    pagination: {
+                        currentPage: 3,
+                        perPage: 10,
+                        lastPage: 5,
+                    },
+                })
+            ).toEqual(
+                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=2&perPage=10>; rel="prev",</api/resources?currentPage=3&perPage=10>; rel="self",</api/resources?currentPage=4&perPage=10>; rel="next",</api/resources?currentPage=5&perPage=10>; rel="last"`
+            );
+        });
+
+        it('should have same first, prev and self elements', () => {
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                    pagination: {
+                        currentPage: 1,
+                        perPage: 10,
+                        lastPage: 3,
+                    },
+                })
+            ).toEqual(
+                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=1&perPage=10>; rel="prev",</api/resources?currentPage=1&perPage=10>; rel="self",</api/resources?currentPage=2&perPage=10>; rel="next",</api/resources?currentPage=3&perPage=10>; rel="last"`
+            );
+        });
+
+        it('should have same self, next and last elements', () => {
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                    pagination: {
+                        currentPage: 3,
+                        perPage: 10,
+                        lastPage: 3,
+                    },
+                })
+            ).toEqual(
+                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=2&perPage=10>; rel="prev",</api/resources?currentPage=3&perPage=10>; rel="self",</api/resources?currentPage=3&perPage=10>; rel="next",</api/resources?currentPage=3&perPage=10>; rel="last"`
+            );
+        });
+
+        it('should have same first, prev, self, next and last elements', () => {
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                    pagination: {
+                        currentPage: 1,
+                        perPage: 10,
+                        lastPage: 1,
+                    },
+                })
+            ).toEqual(
+                `</api/resources?currentPage=1&perPage=10>; rel="first",</api/resources?currentPage=1&perPage=10>; rel="prev",</api/resources?currentPage=1&perPage=10>; rel="self",</api/resources?currentPage=1&perPage=10>; rel="next",</api/resources?currentPage=1&perPage=10>; rel="last"`
+            );
+        });
+
+        it('should contain return null if any element is missing', () => {
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                    pagination: {
+                        currentPage: 3,
+                        perPage: 10,
+                    },
+                })
+            ).toBeNull();
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                    pagination: {
+                        currentPage: 3,
+                        lastPage: 5,
+                    },
+                })
+            ).toBeNull();
+            expect(
+                formatPaginationToLinkHeader({
+                    pagination: {
+                        currentPage: 3,
+                        lastPage: 5,
+                    },
+                })
+            ).toBeNull();
+            expect(
+                formatPaginationToLinkHeader({
+                    resourceURI: '/api/resources',
+                })
+            ).toBeNull();
         });
     });
 });

--- a/apps/api/src/toolbox/sanitizers.spec.js
+++ b/apps/api/src/toolbox/sanitizers.spec.js
@@ -167,17 +167,4 @@ describe('Sanitizers', () => {
             ).toEqual([22, 3]);
         });
     });
-
-    describe('formatPaginationContentRange', () => {
-        it('should transforms the Knex paging object into a string compatible with the "content-Range" header', () => {
-            const knexPagination = {
-                from: 33,
-                to: 42,
-                total: 666,
-            };
-            expect(
-                formatPaginationContentRange('fooOBJECT', knexPagination)
-            ).toEqual('fooobject 33-42/666');
-        });
-    });
 });

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,6 +1,8 @@
 # Architecture Decision Records
 
--   [1. jb-001-utiliser-les-adrs-pour-documenter-le-projet](ccc-jb-001-utiliser-les-adrs-pour-documenter-le-projet.md)
--   [2. jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees](ccc-jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees.md)
--   [3. jb-003-utilisation-de-knex-comme-query-builder](ccc-jb-003-utilisation-de-knex-comme-query-builder.md)
--   [4. jb-004-utilisation-d'oas3-pour-valider-les-points-d'entrées-et-de-sorties-de-l'api](ccc-jb-004-oas3-validation-endpoints.md)
+* [1. jb-001-utiliser-les-adrs-pour-documenter-le-projet](ccc-jb-001-utiliser-les-adrs-pour-documenter-le-projet.md)
+* [2. jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees](ccc-jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees.md)
+* [3. jb-003-utilisation-de-knex-comme-query-builder](ccc-jb-003-utilisation-de-knex-comme-query-builder.md)
+* [4. jb-004-oas3-validation-endpoints](ccc-jb-004-oas3-validation-endpoints.md)
+* [5. jb-005-utilisation-de-paramètres-distincts-pour-la-pagination](ccc-jb-005-utilisation-de-paramètres-distincts-pour-la-pagination.md)
+* [6. jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link](ccc-jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link.md)

--- a/doc/adr/ccc-jb-005-utilisation-de-paramètres-distincts-pour-la-pagination.md
+++ b/doc/adr/ccc-jb-005-utilisation-de-paramètres-distincts-pour-la-pagination.md
@@ -1,0 +1,48 @@
+# 5. Utilisation de paramètres distincts pour la pagination
+
+Date: 2020-04-12
+
+- Décideurs: [Alexis Janvier](https://github.com/alexisjanvier)
+- Ticket.s concerné.s: [!55](https://github.com/CaenCamp/jobs-caen-camp/issues/55)
+- Pull Request: [#62](https://github.com/CaenCamp/jobs-caen-camp/pull/62)
+
+## Statut
+
+2020-04-12 accepted
+
+## Contexte et énoncé du problème
+
+La pagination est actuellement interprétée via un tableau fournit en paramètre des requêtes ce qui pose plusieurs problèmes.
+
+Voici un exemple de pagination : `[10, 1]`
+
+Premièrement, ce format manque de lisibilité et n'est pour le moins pas explicite.
+Deuxièmement, le format utilisé et "stringyfié" rends incomptable son utilisation par React Admin du fait de sa spécification dans le contrat OpenApi.
+
+Une première solution s'offrait alors à nous, celle de ne plus utiliser un tableau mais tout simplement une chaine de caratères mais cela avait un impact négatif et significatif sur les tests couvrant le fonctionnement de la pagination.
+
+Or si l'on regarde les bonnes pratiques concernant la conception d'API REST on s'aperçoit qu'une meilleure implémentation est possible.
+
+## Moteurs de décision
+
+* Rendre plus explicite et lisible l'utilisation de la pagination
+* Coller à un modèle de pagination provenant de "bonnes pratiques"
+
+## Options envisagées
+
+- Utiliser une chaine de caractères à la place d'un tableau
+- Remplacer le paramètre unique par deux paramètres distincts : `perPage` et `currentPage`
+
+## Résultat de la décision
+
+Le remplacement du paramètre unique par deux paramètres distincs a été choisi car cela réponds à l'ensemble des problématiques citées ci-dessus.
+
+### Conséquences positives
+
+* Lisibilité des paramètres de pagination
+* Poursuivre sur la voie de la conception d'une API robuste et cohérente
+
+## Liens
+
+* [Ressources] [Best Practices for Designing a Pragmatic RESTful API - Pagination](https://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#pagination)
+* [Ressources] [REST API Design: Filtering, Sorting, and Pagination - Pagination](https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/#pagination)

--- a/doc/adr/ccc-jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link.md
+++ b/doc/adr/ccc-jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link.md
@@ -1,0 +1,35 @@
+# 6. Remplacement de l'en-tête Content-Range par X-Total-Count et Link
+
+Date: 2020-04-13
+
+- Décideurs: [Alexis Janvier](https://github.com/alexisjanvier)
+- Ticket.s concerné.s: [!55](https://github.com/CaenCamp/jobs-caen-camp/issues/55)
+- Pull Request: [#62](https://github.com/CaenCamp/jobs-caen-camp/pull/62)
+
+## Statut
+
+2020-04-13 accepted
+
+## Contexte et énoncé du problème
+
+L'utilisation de l'en-tête `Content-Range` pour fournir des informations concernant la pagination selon les [spécifications](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range) est inappropriée car celui-ci est normalement utilisé dans l'objectif de fournir une réponse partielle d'un contenu associé à une code de retour spécifique ([206 - Partial Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206)).
+
+Il faut donc trouver un moyen alternif de fournir ces informations.
+
+## Moteurs de décision
+
+* Faire une utilisation correcte des en-têtes conformément aux spécifications
+
+## Options envisagées
+
+* Introduire les objets `meta` et `links` dans le corps de la réponse
+* Ajouter les en-têtes `X-Total-Count` et `Link`
+
+## Résultat de la décision
+
+L'ajout des en-têtes a été choisi car elle n'altère pas le corps de la réponse et permet de continuer à fournir les informations de pagination via les en-têtes comme ce qui était le cas initialement.
+
+## Liens
+
+* [Ressources] [Content-Range - Mozilla Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range)
+* [Ressources] [Link - RFC5988](http://tools.ietf.org/html/rfc5988#page-6)

--- a/tests-e2e/api/job-postings.spec.js
+++ b/tests-e2e/api/job-postings.spec.js
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import frisby from 'frisby';
 import omit from 'lodash.omit';
 
@@ -27,7 +28,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].title).toStrictEqual(
@@ -57,7 +58,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].title).toStrictEqual(
@@ -87,7 +88,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].title).toStrictEqual(
@@ -117,7 +118,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(
@@ -132,13 +133,14 @@ describe('JobPostings API Endpoints', () => {
                 });
         });
 
-        it('devrait pouvoir modifier la pagination avevc le paramètre de requête "pagination"', async () => {
+        it('devrait pouvoir modifier la pagination avec les paramètres de requête "pagination"', async () => {
             expect.hasAssertions();
             await frisby
                 .get(
-                    `http://api:3001/api/job-postings?pagination=${JSON.stringify(
-                        [2, 1]
-                    )}`
+                    `http://api:3001/api/job-postings?${querystring.stringify({
+                        perPage: 2,
+                        currentPage: 1
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -146,15 +148,16 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-2/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(2);
                 });
             await frisby
                 .get(
-                    `http://api:3001/api/job-postings?pagination=${JSON.stringify(
-                        [2, 2]
-                    )}`
+                    `http://api:3001/api/job-postings?${querystring.stringify({
+                        perPage: 2,
+                        currentPage: 2
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -162,7 +165,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 2-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                 });
@@ -182,7 +185,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-2/2')
+                .expect('header', 'x-total-count', '2')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(2);
                     expect(resp.json[0].title).toStrictEqual(
@@ -208,7 +211,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-2/2')
+                .expect('header', 'x-total-count', '2')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(2);
                     expect(resp.json[0].title).toStrictEqual(
@@ -234,7 +237,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-1/1')
+                .expect('header', 'x-total-count', '1')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].title).toStrictEqual(
@@ -257,7 +260,7 @@ describe('JobPostings API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'jobpostings 0-1/1')
+                .expect('header', 'x-total-count', '1')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].title).toStrictEqual(
@@ -541,7 +544,7 @@ describe('JobPostings API Endpoints', () => {
             await frisby
                 .get('http://api:3001/api/job-postings')
                 .expect('status', 200)
-                .expect('header', 'content-range', 'jobpostings 0-4/4')
+                .expect('header', 'x-total-count', '4')
                 .then(resp => {
                     expect(
                         resp.json.find(jb => jb.id === createdJobPosting.id)
@@ -562,7 +565,7 @@ describe('JobPostings API Endpoints', () => {
             return frisby
                 .get('http://api:3001/api/job-postings')
                 .expect('status', 200)
-                .expect('header', 'content-range', 'jobpostings 0-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(
                         resp.json.find(jb => jb.id === createdJobPosting.id)

--- a/tests-e2e/api/job-postings.spec.js
+++ b/tests-e2e/api/job-postings.spec.js
@@ -29,7 +29,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].title).toStrictEqual(
                         'Data Science Lead'
@@ -59,7 +70,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].title).toStrictEqual(
                         'R&D Software Engineer'
@@ -89,7 +111,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].title).toStrictEqual(
                         'Data Science Lead'
@@ -119,7 +152,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(
                         resp.json[0].hiringOrganization.address.postalCode
@@ -139,7 +183,7 @@ describe('JobPostings API Endpoints', () => {
                 .get(
                     `http://api:3001/api/job-postings?${querystring.stringify({
                         perPage: 2,
-                        currentPage: 1
+                        currentPage: 1,
                     })}`
                 )
                 .expect('status', 200)
@@ -149,14 +193,25 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=2>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=2>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=2>; rel="self"',
+                        // '</api/job-postings?currentPage=2&perPage=2>; rel="next"',
+                        // '</api/job-postings?currentPage=2&perPage=2>; rel="last"'
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(2);
                 });
             await frisby
                 .get(
                     `http://api:3001/api/job-postings?${querystring.stringify({
                         perPage: 2,
-                        currentPage: 2
+                        currentPage: 2,
                     })}`
                 )
                 .expect('status', 200)
@@ -166,7 +221,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=2>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=2>; rel="prev"',
+                        // '</api/job-postings?currentPage=2&perPage=2>; rel="self"',
+                        // '</api/job-postings?currentPage=2&perPage=2>; rel="next"',
+                        // '</api/job-postings?currentPage=2&perPage=2>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                 });
         });
@@ -186,7 +252,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '2')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(2);
                     expect(resp.json[0].title).toStrictEqual(
                         'Ingénieur Lead Full Stack technico-fonctionnel'
@@ -212,7 +289,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '2')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(2);
                     expect(resp.json[0].title).toStrictEqual(
                         'Ingénieur Lead Full Stack technico-fonctionnel'
@@ -238,7 +326,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '1')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].title).toStrictEqual(
                         'R&D Software Engineer'
@@ -261,7 +360,18 @@ describe('JobPostings API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '1')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].title).toStrictEqual(
                         'Ingénieur Lead Full Stack technico-fonctionnel'
@@ -285,7 +395,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         "RequestValidationError: Schema validation error ( should have required property 'employmentType')"
                     );
@@ -309,7 +419,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/jobStartDate: format should match format "date")'
                     );
@@ -333,7 +443,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/hiringOrganizationId: format should match format "uuid")'
                     );
@@ -352,7 +462,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'this organization does not exist'
                     );
@@ -364,8 +474,8 @@ describe('JobPostings API Endpoints', () => {
             const organization = await frisby
                 .get('http://api:3001/api/organizations')
                 .expect('status', 200)
-                .then(resp => {
-                    return resp.json.find(org => org.name === 'Flexcity');
+                .then((resp) => {
+                    return resp.json.find((org) => org.name === 'Flexcity');
                 });
             const { json: createdJobPosting } = await frisby
                 .post(
@@ -431,7 +541,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/identifier: format should match format "uuid")'
                     );
@@ -450,7 +560,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'The jobPosting of id 9a6c8995-df54-446c-a5b8-71532c304751 does not exist.'
                     );
@@ -462,9 +572,9 @@ describe('JobPostings API Endpoints', () => {
             const jobPosting = await frisby
                 .get('http://api:3001/api/job-postings')
                 .expect('status', 200)
-                .then(resp => {
+                .then((resp) => {
                     return resp.json.find(
-                        org => org.title === 'Data Science Lead'
+                        (org) => org.title === 'Data Science Lead'
                     );
                 });
 
@@ -476,7 +586,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.title).toEqual('Data Science Lead');
                 });
         });
@@ -493,7 +603,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/identifier: format should match format "uuid")'
                     );
@@ -512,7 +622,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'The jobPosting of id 9a6c8995-df54-446c-a5b8-71532c304751 does not exist.'
                     );
@@ -524,8 +634,8 @@ describe('JobPostings API Endpoints', () => {
             const organization = await frisby
                 .get('http://api:3001/api/organizations')
                 .expect('status', 200)
-                .then(resp => {
-                    return resp.json.find(org => org.name === 'Flexcity');
+                .then((resp) => {
+                    return resp.json.find((org) => org.name === 'Flexcity');
                 });
 
             // A new job posting is being created
@@ -545,9 +655,20 @@ describe('JobPostings API Endpoints', () => {
                 .get('http://api:3001/api/job-postings')
                 .expect('status', 200)
                 .expect('header', 'x-total-count', '4')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=2&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=2&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(
-                        resp.json.find(jb => jb.id === createdJobPosting.id)
+                        resp.json.find((jb) => jb.id === createdJobPosting.id)
                     ).toBeTruthy();
                 });
 
@@ -557,7 +678,7 @@ describe('JobPostings API Endpoints', () => {
                     `http://api:3001/api/job-postings/${createdJobPosting.id}`
                 )
                 .expect('status', 200)
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.id).toEqual(createdJobPosting.id);
                 });
 
@@ -566,9 +687,20 @@ describe('JobPostings API Endpoints', () => {
                 .get('http://api:3001/api/job-postings')
                 .expect('status', 200)
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/job-postings?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/job-postings?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(
-                        resp.json.find(jb => jb.id === createdJobPosting.id)
+                        resp.json.find((jb) => jb.id === createdJobPosting.id)
                     ).toBeFalsy();
                 });
         });
@@ -589,7 +721,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/identifier: format should match format "uuid")'
                     );
@@ -609,7 +741,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         "RequestValidationError: Schema validation error ( should have required property 'employmentType')"
                     );
@@ -633,7 +765,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/jobStartDate: format should match format "date")'
                     );
@@ -654,7 +786,7 @@ describe('JobPostings API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'The jobPosting of id b6c2cd95-1dfa-4fa0-a776-8f125918c45c does not exist, so it could not be updated'
                     );
@@ -666,9 +798,9 @@ describe('JobPostings API Endpoints', () => {
             const jobPosting = await frisby
                 .get('http://api:3001/api/job-postings')
                 .expect('status', 200)
-                .then(resp => {
+                .then((resp) => {
                     return resp.json.find(
-                        org => org.title === 'Data Science Lead'
+                        (org) => org.title === 'Data Science Lead'
                     );
                 });
 
@@ -683,7 +815,7 @@ describe('JobPostings API Endpoints', () => {
                     { json: true }
                 )
                 .expect('status', 400)
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'the new hiring organization does not exist'
                     );
@@ -695,8 +827,8 @@ describe('JobPostings API Endpoints', () => {
             const organization = await frisby
                 .get('http://api:3001/api/organizations')
                 .expect('status', 200)
-                .then(resp => {
-                    return resp.json.find(org => org.name === 'Flexcity');
+                .then((resp) => {
+                    return resp.json.find((org) => org.name === 'Flexcity');
                 });
 
             const { json: createdJobPosting } = await frisby
@@ -731,7 +863,7 @@ describe('JobPostings API Endpoints', () => {
                     { json: true }
                 )
                 .expect('status', 200)
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.title).toEqual('Developpeur Php');
                     expect(resp.json.hiringOrganization.identifier).toEqual(
                         organization.id
@@ -750,13 +882,13 @@ describe('JobPostings API Endpoints', () => {
             const organizations = await frisby
                 .get('http://api:3001/api/organizations')
                 .expect('status', 200)
-                .then(resp => resp.json);
+                .then((resp) => resp.json);
 
             const firstOrganization = organizations.find(
-                org => org.name === 'Flexcity'
+                (org) => org.name === 'Flexcity'
             );
             const secondOrganization = organizations.find(
-                org => org.name === 'Limengo'
+                (org) => org.name === 'Limengo'
             );
 
             const { json: createdJobPosting } = await frisby
@@ -791,7 +923,7 @@ describe('JobPostings API Endpoints', () => {
                     { json: true }
                 )
                 .expect('status', 200)
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.hiringOrganization.name).toEqual(
                         'Limengo'
                     );

--- a/tests-e2e/api/organizations.spec.js
+++ b/tests-e2e/api/organizations.spec.js
@@ -18,7 +18,7 @@ const incompleteDataForCreation = {
             email: 'job@org.org',
             telephone: '0606060606',
             name: 'John Do, CTO',
-            contactType: 'Offres d\'emploi',
+            contactType: "Offres d'emploi",
         },
     ],
 };
@@ -30,7 +30,7 @@ const completeDataForCreation = {
 
 describe('Organizations API Endpoints', () => {
     describe('GET: /api/organizations', () => {
-        it('devrait renvoyer une liste paginée ordonnée par nom d\'entreprise sans paramètres de requête', async () => {
+        it("devrait renvoyer une liste paginée ordonnée par nom d'entreprise sans paramètres de requête", async () => {
             expect.hasAssertions();
             await frisby
                 .get('http://api:3001/api/organizations')
@@ -41,7 +41,18 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/organizations?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
                     expect(resp.json[1].name).toStrictEqual('Limengo');
@@ -55,7 +66,7 @@ describe('Organizations API Endpoints', () => {
                 .get(
                     `http://api:3001/api/organizations?${querystring.stringify({
                         perPage: 1,
-                        currentPage: 1
+                        currentPage: 1,
                     })}`
                 )
                 .expect('status', 200)
@@ -65,7 +76,18 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/organizations?currentPage=1&perPage=1>; rel="first"',
+                        // '</api/organizations?currentPage=1&perPage=1>; rel="prev"',
+                        // '</api/organizations?currentPage=1&perPage=1>; rel="self"',
+                        // '</api/organizations?currentPage=2&perPage=1>; rel="next"',
+                        // '</api/organizations?currentPage=3&perPage=1>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
                 });
@@ -73,7 +95,7 @@ describe('Organizations API Endpoints', () => {
                 .get(
                     `http://api:3001/api/organizations?${querystring.stringify({
                         perPage: 1,
-                        currentPage: 3
+                        currentPage: 3,
                     })}`
                 )
                 .expect('status', 200)
@@ -83,7 +105,18 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '3')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/organizations?currentPage=1&perPage=1>; rel="first"',
+                        // '</api/organizations?currentPage=2&perPage=1>; rel="prev"',
+                        // '</api/organizations?currentPage=3&perPage=1>; rel="self"',
+                        // '</api/organizations?currentPage=3&perPage=1>; rel="next"',
+                        // '</api/organizations?currentPage=3&perPage=1>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Qwarry');
                 });
@@ -99,7 +132,7 @@ describe('Organizations API Endpoints', () => {
                     ])}`
                 )
                 .expect('status', 200)
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
                     expect(resp.json[1].name).toStrictEqual('Limengo');
@@ -112,7 +145,7 @@ describe('Organizations API Endpoints', () => {
                         'DESC',
                     ])}`
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].name).toStrictEqual('Qwarry');
                     expect(resp.json[1].name).toStrictEqual('Limengo');
@@ -135,7 +168,18 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '1')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/organizations?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
                 });
@@ -156,7 +200,18 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '1')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/organizations?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
                 });
@@ -173,7 +228,7 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '0')
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(0);
                 });
         });
@@ -193,7 +248,18 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '2')
-                .then(resp => {
+                .expect(
+                    'header',
+                    'link',
+                    [
+                        '</api/organizations?currentPage=1&perPage=10>; rel="first"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="prev"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="self"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="next"',
+                        // '</api/organizations?currentPage=1&perPage=10>; rel="last"',
+                    ].join(',')
+                )
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(2);
                 });
             await frisby
@@ -209,7 +275,7 @@ describe('Organizations API Endpoints', () => {
                     'application/json; charset=utf-8'
                 )
                 .expect('header', 'x-total-count', '0')
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.length).toStrictEqual(0);
                 });
         });
@@ -230,9 +296,9 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
-                        'RequestValidationError: Schema validation error ( should have required property \'name\')'
+                        "RequestValidationError: Schema validation error ( should have required property 'name')"
                     );
                 });
         });
@@ -254,14 +320,14 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/email: format should match format "email")'
                     );
                 });
         });
 
-        it('devrait retourner l\'entreprise crée avec un nouvel id en cas de succès', async () => {
+        it("devrait retourner l'entreprise crée avec un nouvel id en cas de succès", async () => {
             expect.hasAssertions();
             await frisby
                 .post(
@@ -275,7 +341,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.id).not.toBeUndefined();
                     expect(resp.json.address).toEqual({
                         addressCountry: 'FR',
@@ -315,7 +381,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.contactPoints.length).toEqual(2);
                     return frisby
                         .delete(
@@ -327,7 +393,7 @@ describe('Organizations API Endpoints', () => {
     });
 
     describe('GET: /api/organizations/:organizationId', () => {
-        it('devrait retourner une erreur 400 en cas d\'id mal formaté', async () => {
+        it("devrait retourner une erreur 400 en cas d'id mal formaté", async () => {
             expect.hasAssertions();
             await frisby
                 .get('http://api:3001/api/organizations/id-mal-formaté')
@@ -337,14 +403,14 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/identifier: format should match format "uuid")'
                     );
                 });
         });
 
-        it('devrait retourner une erreur 404 en cas d\'id n\'existant pas en base de données', async () => {
+        it("devrait retourner une erreur 404 en cas d'id n'existant pas en base de données", async () => {
             expect.hasAssertions();
             await frisby
                 .get(
@@ -356,7 +422,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'The organization of id 9a6c8995-df54-446c-a5b8-71532c304751 does not exist.'
                     );
@@ -368,8 +434,10 @@ describe('Organizations API Endpoints', () => {
             await frisby
                 .get('http://api:3001/api/organizations')
                 .expect('status', 200)
-                .then(async resp => {
-                    const qwarry = resp.json.find(org => org.name === 'Qwarry');
+                .then(async (resp) => {
+                    const qwarry = resp.json.find(
+                        (org) => org.name === 'Qwarry'
+                    );
                     const qwarryFromGet = await frisby
                         .get(`http://api:3001/api/organizations/${qwarry.id}`)
                         .expect('status', 200)
@@ -385,7 +453,7 @@ describe('Organizations API Endpoints', () => {
     });
 
     describe('DELETE: /api/organizations/:organizationId', () => {
-        it('devrait retourner une erreur 400 en cas d\'id mal formaté', async () => {
+        it("devrait retourner une erreur 400 en cas d'id mal formaté", async () => {
             expect.hasAssertions();
             await frisby
                 .delete('http://api:3001/api/organizations/id-mal-formaté')
@@ -395,14 +463,14 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/identifier: format should match format "uuid")'
                     );
                 });
         });
 
-        it('devrait retourner une erreur 404 en cas d\'id n\'existant pas en base de données', async () => {
+        it("devrait retourner une erreur 404 en cas d'id n'existant pas en base de données", async () => {
             expect.hasAssertions();
             await frisby
                 .delete(
@@ -414,14 +482,14 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'The organization of id 9a6c8995-df54-446c-a5b8-71532c304751 does not exist.'
                     );
                 });
         });
 
-        it('devrait retourner l\'identifiant de l\'entreprise supprimée en cas de succes', async () => {
+        it("devrait retourner l'identifiant de l'entreprise supprimée en cas de succes", async () => {
             expect.hasAssertions();
             await frisby
                 .post(
@@ -439,10 +507,21 @@ describe('Organizations API Endpoints', () => {
                     const { json: organizationList } = await frisby
                         .get('http://api:3001/api/organizations')
                         .expect('status', 200)
-                        .expect('header', 'x-total-count', '4');
+                        .expect('header', 'x-total-count', '4')
+                        .expect(
+                            'header',
+                            'link',
+                            [
+                                '</api/organizations?currentPage=1&perPage=10>; rel="first"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="prev"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="self"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="next"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="last"',
+                            ].join(',')
+                        );
                     expect(
                         organizationList.find(
-                            org => org.id === newOrganization.id
+                            (org) => org.id === newOrganization.id
                         )
                     ).toBeTruthy();
                     await frisby
@@ -453,10 +532,21 @@ describe('Organizations API Endpoints', () => {
                     const { json: updatedOrganizationList } = await frisby
                         .get('http://api:3001/api/organizations')
                         .expect('status', 200)
-                        .expect('header', 'x-total-count', '3');
+                        .expect('header', 'x-total-count', '3')
+                        .expect(
+                            'header',
+                            'link',
+                            [
+                                '</api/organizations?currentPage=1&perPage=10>; rel="first"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="prev"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="self"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="next"',
+                                // '</api/organizations?currentPage=1&perPage=10>; rel="last"',
+                            ].join(',')
+                        );
                     expect(
                         updatedOrganizationList.find(
-                            org => org.id === newOrganization.id
+                            (org) => org.id === newOrganization.id
                         )
                     ).toBeFalsy();
                 });
@@ -464,11 +554,11 @@ describe('Organizations API Endpoints', () => {
     });
 
     describe('PUT: /api/organizations/:organizationId', () => {
-        it('devrait retourner une erreur 404 en cas d\'id n\'existant pas en base de données', async () => {
+        it("devrait retourner une erreur 404 en cas d'id n'existant pas en base de données", async () => {
             const completeDataForEdition = {
                 ...completeDataForCreation,
                 contactPoints: completeDataForCreation.contactPoints.map(
-                    contact => ({
+                    (contact) => ({
                         identifier: '999904e7-37a3-4eaf-92bb-4f51f70dc595',
                         ...contact,
                     })
@@ -487,14 +577,14 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'The organization of id 9a6c8995-df54-446c-a5b8-71532c304751 does not exist, so it could not be updated'
                     );
                 });
         });
 
-        it('devrait retourner une erreur 400 en cas d\'id mal formaté', async () => {
+        it("devrait retourner une erreur 400 en cas d'id mal formaté", async () => {
             expect.hasAssertions();
             await frisby
                 .put(
@@ -508,14 +598,14 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .then(resp => {
+                .then((resp) => {
                     expect(resp.json.message).toEqual(
                         'RequestValidationError: Schema validation error (/identifier: format should match format "uuid")'
                     );
                 });
         });
 
-        it('devrait retourner une erreur 400 si il manque une donnée sur l\'entreprise', async () => {
+        it("devrait retourner une erreur 400 si il manque une donnée sur l'entreprise", async () => {
             expect.hasAssertions();
             await frisby
                 .post(
@@ -543,9 +633,9 @@ describe('Organizations API Endpoints', () => {
                             'Content-Type',
                             'application/json; charset=utf-8'
                         )
-                        .then(resp => {
+                        .then((resp) => {
                             expect(resp.json.message).toEqual(
-                                'RequestValidationError: Schema validation error ( should have required property \'name\')'
+                                "RequestValidationError: Schema validation error ( should have required property 'name')"
                             );
                         });
                     return frisby
@@ -556,7 +646,7 @@ describe('Organizations API Endpoints', () => {
                 });
         });
 
-        it('devrait retourner une erreur 400 si une donnée sur l\'entreprise est mal formatée', async () => {
+        it("devrait retourner une erreur 400 si une donnée sur l'entreprise est mal formatée", async () => {
             expect.hasAssertions();
             await frisby
                 .post(
@@ -587,7 +677,7 @@ describe('Organizations API Endpoints', () => {
                             'Content-Type',
                             'application/json; charset=utf-8'
                         )
-                        .then(resp => {
+                        .then((resp) => {
                             expect(resp.json.message).toEqual(
                                 'RequestValidationError: Schema validation error (/email: format should match format "email")'
                             );
@@ -618,7 +708,7 @@ describe('Organizations API Endpoints', () => {
                     const incompleteOrganization = {
                         ...organization,
                         contactPoints: organization.contactPoints.map(
-                            contact => ({ ...omit(contact, ['email']) })
+                            (contact) => ({ ...omit(contact, ['email']) })
                         ),
                     };
                     await frisby
@@ -633,9 +723,9 @@ describe('Organizations API Endpoints', () => {
                             'Content-Type',
                             'application/json; charset=utf-8'
                         )
-                        .then(resp => {
+                        .then((resp) => {
                             expect(resp.json.message).toEqual(
-                                'RequestValidationError: Schema validation error (/contactPoints/0 should have required property \'email\')'
+                                "RequestValidationError: Schema validation error (/contactPoints/0 should have required property 'email')"
                             );
                         });
                     return frisby
@@ -664,7 +754,7 @@ describe('Organizations API Endpoints', () => {
                     const notWellFormatedOrganization = {
                         ...organization,
                         contactPoints: organization.contactPoints.map(
-                            contact => ({
+                            (contact) => ({
                                 ...contact,
                                 email: 'not-an-email',
                             })
@@ -682,7 +772,7 @@ describe('Organizations API Endpoints', () => {
                             'Content-Type',
                             'application/json; charset=utf-8'
                         )
-                        .then(resp => {
+                        .then((resp) => {
                             expect(resp.json.message).toEqual(
                                 'RequestValidationError: Schema validation error (/contactPoints/0/email: format should match format "email")'
                             );
@@ -714,7 +804,7 @@ describe('Organizations API Endpoints', () => {
                         ...omit(organization, ['id']),
                         name: 'Ma petite entreprise',
                         contactPoints: organization.contactPoints.map(
-                            contact => ({
+                            (contact) => ({
                                 ...contact,
                                 name: 'Alain B.',
                             })
@@ -732,7 +822,7 @@ describe('Organizations API Endpoints', () => {
                             'Content-Type',
                             'application/json; charset=utf-8'
                         )
-                        .then(resp => {
+                        .then((resp) => {
                             expect(resp.json.name).toEqual(
                                 'Ma petite entreprise'
                             );
@@ -741,7 +831,7 @@ describe('Organizations API Endpoints', () => {
                                     `http://api:3001/api/organizations/${organization.id}`
                                 )
                                 .expect('status', 200)
-                                .then(resp => {
+                                .then((resp) => {
                                     expect(resp.json.name).toEqual(
                                         'Ma petite entreprise'
                                     );
@@ -758,7 +848,7 @@ describe('Organizations API Endpoints', () => {
                 });
         });
 
-        it('devrait permettre d\'ajouter et de supprimer des contacts', async () => {
+        it("devrait permettre d'ajouter et de supprimer des contacts", async () => {
             expect.hasAssertions();
             await frisby
                 .post(
@@ -804,7 +894,7 @@ describe('Organizations API Endpoints', () => {
                                     `http://api:3001/api/organizations/${organization.id}`
                                 )
                                 .expect('status', 200)
-                                .then(resp => {
+                                .then((resp) => {
                                     expect(
                                         resp.json.contactPoints.length
                                     ).toEqual(2);
@@ -819,9 +909,9 @@ describe('Organizations API Endpoints', () => {
                                 ...updatedData,
                                 contactPoints: updatedContactPoints
                                     .filter(
-                                        contact => contact.name === 'John C.'
+                                        (contact) => contact.name === 'John C.'
                                     )
-                                    .map(contact => ({
+                                    .map((contact) => ({
                                         ...contact,
                                         email: 'john-updated@impulse.com',
                                     })),
@@ -840,7 +930,7 @@ describe('Organizations API Endpoints', () => {
                                     `http://api:3001/api/organizations/${organization.id}`
                                 )
                                 .expect('status', 200)
-                                .then(resp => {
+                                .then((resp) => {
                                     expect(
                                         resp.json.contactPoints.length
                                     ).toEqual(1);

--- a/tests-e2e/api/organizations.spec.js
+++ b/tests-e2e/api/organizations.spec.js
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import frisby from 'frisby';
 import omit from 'lodash.omit';
 
@@ -39,7 +40,7 @@ describe('Organizations API Endpoints', () => {
                     'content-type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'content-range', 'organizations 0-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(3);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
@@ -48,13 +49,14 @@ describe('Organizations API Endpoints', () => {
                 });
         });
 
-        it('devrait changer la pagination via le paramètre de requête pagination', async () => {
+        it('devrait changer la pagination via les paramètres de requête pagination', async () => {
             expect.hasAssertions();
             await frisby
                 .get(
-                    `http://api:3001/api/organizations?pagination=${JSON.stringify(
-                        [1, 1]
-                    )}`
+                    `http://api:3001/api/organizations?${querystring.stringify({
+                        perPage: 1,
+                        currentPage: 1
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -62,16 +64,17 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 0-1/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
                 });
             await frisby
                 .get(
-                    `http://api:3001/api/organizations?pagination=${JSON.stringify(
-                        [1, 3]
-                    )}`
+                    `http://api:3001/api/organizations?${querystring.stringify({
+                        perPage: 1,
+                        currentPage: 3
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -79,7 +82,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 2-3/3')
+                .expect('header', 'x-total-count', '3')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Qwarry');
@@ -131,7 +134,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 0-1/1')
+                .expect('header', 'x-total-count', '1')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
@@ -152,7 +155,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 0-1/1')
+                .expect('header', 'x-total-count', '1')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(1);
                     expect(resp.json[0].name).toStrictEqual('Flexcity');
@@ -169,7 +172,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 0-0/0')
+                .expect('header', 'x-total-count', '0')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(0);
                 });
@@ -189,7 +192,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 0-2/2')
+                .expect('header', 'x-total-count', '2')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(2);
                 });
@@ -205,7 +208,7 @@ describe('Organizations API Endpoints', () => {
                     'Content-Type',
                     'application/json; charset=utf-8'
                 )
-                .expect('header', 'Content-Range', 'organizations 0-0/0')
+                .expect('header', 'x-total-count', '0')
                 .then(resp => {
                     expect(resp.json.length).toStrictEqual(0);
                 });
@@ -436,11 +439,7 @@ describe('Organizations API Endpoints', () => {
                     const { json: organizationList } = await frisby
                         .get('http://api:3001/api/organizations')
                         .expect('status', 200)
-                        .expect(
-                            'header',
-                            'content-range',
-                            'organizations 0-4/4'
-                        );
+                        .expect('header', 'x-total-count', '4');
                     expect(
                         organizationList.find(
                             org => org.id === newOrganization.id
@@ -454,11 +453,7 @@ describe('Organizations API Endpoints', () => {
                     const { json: updatedOrganizationList } = await frisby
                         .get('http://api:3001/api/organizations')
                         .expect('status', 200)
-                        .expect(
-                            'header',
-                            'content-range',
-                            'organizations 0-3/3'
-                        );
+                        .expect('header', 'x-total-count', '3');
                     expect(
                         updatedOrganizationList.find(
                             org => org.id === newOrganization.id


### PR DESCRIPTION
# Description

Cette PR concerne la refonte de la pagination.

Elle implique les changements suivants :
- Suppression du paramètre de requête unique `pagination`
- Ajout de deux paramètres distincts `perPage` & `currentPage`
- Suppression de l'en-tête `Content-Range`
- Ajout des en-têtes `X-Total-Count` & `Link`

Les tests concernant l'en-tête `Link` sont en partie commentés à cause d'une erreur d'interprétation de la value d'en-tête faite par Frisby. J'ai signalé l'erreur ici : https://github.com/vlucas/frisby/issues/557. À voir comment l'erreur est traitée pour ajuster les tests.

# Related Issue

close #55 

# ToDo

- [x] Mise à jour du fichier OpenApi
- [x] Ajout des nouveaux paramètres de pagination
- [x] Implémenter l'en-tête `X-Total-Count`
- [x] Implémenter l'en-tête `Link`
- [x] Mise à jour du `dataProvider` React Admin
- [x] Couvrir avec des tests unitaires et bout en bout
- [x] Rédaction d'un ADR
