### PR TITLE
Refactor api sort

### DIFF
--- a/apps/admin/src/jobBoardDataProvider.js
+++ b/apps/admin/src/jobBoardDataProvider.js
@@ -17,7 +17,7 @@ const getXTotalCountHeaderValue = (headers) => {
  *
  * @example
  *
- * getList     => GET http://my.api.url/posts?sort=['title','ASC']&currentPage=1&perPage=24
+ * getList     => GET http://my.api.url/posts?sortBy=title&orderBy=ASC&currentPage=1&perPage=24
  * getOne      => GET http://my.api.url/posts/123
  * getMany     => GET http://my.api.url/posts?filter={id:[123,456,789]}&currentPage=1&perPage=24
  * update      => PUT http://my.api.url/posts/123
@@ -29,7 +29,8 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => ({
         const { currentPage, perPage } = params;
         const { field, order } = params.sort;
         const query = {
-            sort: JSON.stringify([field, order]),
+            sortBy: field,
+            orderBy: order,
             filters: JSON.stringify(params.filter),
             currentPage,
             perPage,
@@ -61,7 +62,8 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => ({
         const { currentPage, perPage } = params;
         const { field, order } = params.sort;
         const query = {
-            sort: JSON.stringify([field, order]),
+            sortBy: field,
+            orderBy: order,
             filters: JSON.stringify({
                 ...params.filter,
                 [params.target]: params.id,

--- a/apps/api/openapi/openapi.yaml
+++ b/apps/api/openapi/openapi.yaml
@@ -105,7 +105,7 @@ paths:
         * hiringOrganizationAddressLocality
         * hiringOrganizationAddressCountry
 
-        Cette liste est triable par sort=[key, sortDirection_ASC_DESC] :
+        Cette liste est triable par sortBy=key, orderBy=ASC (ou DESC) :
         * datePosted
         * title
         * jobStartDate
@@ -116,7 +116,8 @@ paths:
         * hiringOrganizationAddressLocality
         * hiringOrganizationAddressCountry
       parameters:
-        - $ref: '#/components/parameters/Sort'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
         - $ref: '#/components/parameters/Filter'
         - $ref: '#/components/parameters/PaginationCurrentPage'
         - $ref: '#/components/parameters/PaginationPerPage'
@@ -472,13 +473,14 @@ paths:
         * address_locality
         * postal_code
 
-        Cette liste est triable par sort=[key, sortDirection_ASC_DESC] :
+        Cette liste est triable par sortBy=key, orderBy=ASC (ou DESC) :
         * name
         * address_locality
         * postal_code
       parameters:
         - $ref: '#/components/parameters/Filter'
-        - $ref: '#/components/parameters/Sort'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
         - $ref: '#/components/parameters/PaginationCurrentPage'
         - $ref: '#/components/parameters/PaginationPerPage'
     post:
@@ -1111,18 +1113,22 @@ components:
       explode: true
       schema:
         type: string
-    Sort:
-      name: sort
+    SortBy:
+      name: sortBy
       in: query
-      description: "Le tri applicable à la liste. C'est un tableau stringifié de la forme [sortProp, sortDirection]"
+      description: "Le paramètre de tri des résultats (ex: par titre, par date...)"
       required: false
-      explode: false
       schema:
-        type: array
-        maxItems: 2
-        minItems: 2
-        items:
-          type: string
+        type: string
+        example: 'datePosted'
+    OrderBy:
+      name: orderBy
+      in: query
+      description: "Le paramètre de tri ascendant ou descendant (ASC ou DESC)"
+      required: false
+      schema:
+        type: string
+        example: 'ASC'
     PaginationCurrentPage:
       name: currentPage
       in: query

--- a/apps/api/src/job-posting/repository.js
+++ b/apps/api/src/job-posting/repository.js
@@ -41,7 +41,7 @@ const jobPostingFilterableFields = [
  *
  * @param {object} client - The Database client
  * @param {object} filters - jobPosting Filter
- * @param {Array} sort - Sort parameters [columnName, direction]
+ * @param {object} sort - Sort parameters { sortBy, orderBy }
  * @returns {Promise} - Knew query for filtrated jobPosting list
  */
 const getFilteredJobPostingsQuery = (client, filters, sort) => {
@@ -180,7 +180,7 @@ const formatJobPostingForAPI = (dbJobPosting) => {
  *
  * @param {object} client - The Database client
  * @param {object} filters - JobPosting Filters
- * @param {Array} sort - Sort parameters [columnName, direction]
+ * @param {object} sort - Sort parameters {sortBy: title, orderBy: ASC}
  * @param {object} pagination - Pagination {perPage: 10, currentPage: 1}
  * @returns {Promise} - paginated object with paginated jobPosting list and totalCount
  */

--- a/apps/api/src/job-posting/router.js
+++ b/apps/api/src/job-posting/router.js
@@ -20,7 +20,10 @@ router.get('/', async (ctx) => {
     const { jobPostings, pagination } = await getJobPostingPaginatedList({
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
-        sort: parseJsonQueryParameter(ctx.query.sort),
+        sort: {
+            sortBy: ctx.query.sortBy,
+            orderBy: ctx.query.orderBy,
+        },
         pagination: {
             currentPage: ctx.query.currentPage,
             perPage: ctx.query.perPage,

--- a/apps/api/src/organization/repository.js
+++ b/apps/api/src/organization/repository.js
@@ -25,7 +25,7 @@ const OrganizationSortableFields = [
  *
  * @param {object} client - The Database client
  * @param {object} filters - Organization Filter
- * @param {Array} sort - Sort parameters [columnName, direction]
+ * @param {object} sort - Sort parameters { sortBy, orderBy }
  * @returns {Promise} - Knew query for filtrated organization list
  */
 const getFilteredOrganizationsQuery = (client, filters, sort) => {
@@ -96,7 +96,7 @@ const formatOrganizationForAPI = (dbOrganization) => ({
  *
  * @param {object} client - The Database client
  * @param {object} filters - Organization Filter
- * @param {Array} sort - Sort parameters [columnName, direction]
+ * @param {object} sort - Sort parameters { sortBy, orderBy }
  * @param {object} pagination - Pagination {perPage: 10, currentPage: 1}
  * @returns {Promise} - paginated object with paginated organization list and totalCount
  */

--- a/apps/api/src/organization/router.js
+++ b/apps/api/src/organization/router.js
@@ -20,7 +20,10 @@ router.get('/', async (ctx) => {
     const { organizations, pagination } = await getOrganizationPaginatedList({
         client: ctx.db,
         filters: parseJsonQueryParameter(ctx.query.filters),
-        sort: parseJsonQueryParameter(ctx.query.sort),
+        sort: {
+            sortBy: ctx.query.sortBy,
+            orderBy: ctx.query.orderBy,
+        },
         pagination: {
             currentPage: ctx.query.currentPage,
             perPage: ctx.query.perPage,

--- a/apps/api/src/toolbox/sanitizers.js
+++ b/apps/api/src/toolbox/sanitizers.js
@@ -31,26 +31,19 @@ const filtersSanitizer = (filters, filterableFields) => {
  * Method to clean the sort sent in query parameters
  *
  * @param {object} sort - sort from query parameters
- * @param {object} sortableFields the fields allowed to be used as a sort
- * @returns {object} Ready-to-use filters for the sql query
+ * @param {Array} sortableFields the fields allowed to be used as a sort
+ * @returns {Array} Ready-to-use filters for the sql query
  */
-const sortSanitizer = (sort, sortableFields) => {
-    const sortTwoFirstParameters = [
-        sort ? sort[0] || null : null,
-        sort ? sort[1] || null : null,
-    ];
-    if (
-        !sortTwoFirstParameters ||
-        !sortableFields.includes(sortTwoFirstParameters[0])
-    ) {
+const sortSanitizer = ({ sortBy, orderBy }, sortableFields) => {
+    if (orderBy === undefined || !sortableFields.includes(sortBy)) {
         return [sortableFields[0], 'ASC'];
     }
 
-    if (!['ASC', 'DESC'].includes(sort[1])) {
-        return [sortTwoFirstParameters[0], 'ASC'];
+    if (!['ASC', 'DESC'].includes(orderBy)) {
+        return [sortBy, 'ASC'];
     }
 
-    return sortTwoFirstParameters;
+    return [sortBy, orderBy];
 };
 
 /**

--- a/apps/api/src/toolbox/sanitizers.spec.js
+++ b/apps/api/src/toolbox/sanitizers.spec.js
@@ -83,40 +83,51 @@ describe('Sanitizers', () => {
     });
 
     describe('sortSanitizer', () => {
-        it('should return the first sortable field ASC if query sort are not set', () => {
-            const defaultSortableFields = ['foo', 'bar'];
-            expect(sortSanitizer(undefined, defaultSortableFields)).toEqual([
-                'foo',
-                'ASC',
-            ]);
-        });
-
-        it('should return the first sortable field ASC if query sort is not an array', () => {
+        it('should return the first sortable field ASC if sortBy is not set', () => {
             const defaultSortableFields = ['foo', 'bar'];
             expect(
-                sortSanitizer({ bar: 'DESC' }, defaultSortableFields)
+                sortSanitizer(
+                    { sortBy: undefined, orderBy: 'DESC' },
+                    defaultSortableFields
+                )
+            ).toEqual(['foo', 'ASC']);
+        });
+
+        it('should return the first sortable field ASC if orderBy is not set', () => {
+            const defaultSortableFields = ['foo', 'bar'];
+            expect(
+                sortSanitizer(
+                    { sortBy: 'bar', orderBy: undefined },
+                    defaultSortableFields
+                )
             ).toEqual(['foo', 'ASC']);
         });
 
         it('should return the first sortable field ASC if query sort is not a sortable field', () => {
             const defaultSortableFields = ['foo', 'bar'];
             expect(
-                sortSanitizer(['notSortable', 'DESC'], defaultSortableFields)
+                sortSanitizer(
+                    { sortBy: 'notSortable', orderBy: 'DESC' },
+                    defaultSortableFields
+                )
             ).toEqual(['foo', 'ASC']);
         });
 
         it('should replace the sort order with ASC if the query param sort order is not valid', () => {
             const defaultSortableFields = ['foo', 'bar'];
             expect(
-                sortSanitizer(['bar', 'horizontal'], defaultSortableFields)
+                sortSanitizer(
+                    { sortBy: 'bar', orderBy: 'horizontal' },
+                    defaultSortableFields
+                )
             ).toEqual(['bar', 'ASC']);
         });
 
-        it('should remove the supernumerary parameters of the sorting array', () => {
+        it('should remove the supernumerary parameters of the sort object', () => {
             const defaultSortableFields = ['foo', 'bar'];
             expect(
                 sortSanitizer(
-                    ['bar', 'DESC', 'this', 'is', 'too', 'much'],
+                    { sortBy: 'bar', orderBy: 'DESC', nonsense: 'this' },
                     defaultSortableFields
                 )
             ).toEqual(['bar', 'DESC']);
@@ -125,7 +136,10 @@ describe('Sanitizers', () => {
         it('should return a well formated sort from query parameter', () => {
             const defaultSortableFields = ['foo', 'bar'];
             expect(
-                sortSanitizer(['bar', 'DESC'], defaultSortableFields)
+                sortSanitizer(
+                    { sortBy: 'bar', orderBy: 'DESC' },
+                    defaultSortableFields
+                )
             ).toEqual(['bar', 'DESC']);
         });
     });

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,8 +1,9 @@
 # Architecture Decision Records
 
--   [1. jb-001-utiliser-les-adrs-pour-documenter-le-projet](ccc-jb-001-utiliser-les-adrs-pour-documenter-le-projet.md)
--   [2. jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees](ccc-jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees.md)
--   [3. jb-003-utilisation-de-knex-comme-query-builder](ccc-jb-003-utilisation-de-knex-comme-query-builder.md)
--   [4. jb-004-oas3-validation-endpoints](ccc-jb-004-oas3-validation-endpoints.md)
--   [5. jb-005-utilisation-de-paramètres-distincts-pour-la-pagination](ccc-jb-005-utilisation-de-paramètres-distincts-pour-la-pagination.md)
--   [6. jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link](ccc-jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link.md)
+* [1. jb-001-utiliser-les-adrs-pour-documenter-le-projet](ccc-jb-001-utiliser-les-adrs-pour-documenter-le-projet.md)
+* [2. jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees](ccc-jb-002-utilisation-de-postgresql-pour-la-persistance-des-donnees.md)
+* [3. jb-003-utilisation-de-knex-comme-query-builder](ccc-jb-003-utilisation-de-knex-comme-query-builder.md)
+* [4. jb-004-oas3-validation-endpoints](ccc-jb-004-oas3-validation-endpoints.md)
+* [5. jb-005-utilisation-de-paramètres-distincts-pour-la-pagination](ccc-jb-005-utilisation-de-paramètres-distincts-pour-la-pagination.md)
+* [6. jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link](ccc-jb-006-remplacement-de-l'en-tête-content-range-par-x-total-count-et-link.md)
+* [7. jb-007-utilisation-de-paramètres-distincts-pour-le-tri](ccc-jb-007-utilisation-de-paramètres-distincts-pour-le-tri.md)

--- a/doc/adr/ccc-jb-007-utilisation-de-paramètres-distincts-pour-le-tri.md
+++ b/doc/adr/ccc-jb-007-utilisation-de-paramètres-distincts-pour-le-tri.md
@@ -1,0 +1,75 @@
+# 7. utilisation de paramètres distincts pour le tri
+
+Date: 2020-04-22
+
+Décideurs: [Alexis Janvier](https://github.com/alexisjanvier)
+Ticket.s concerné.s: [!56](https://github.com/CaenCamp/jobs-caen-camp/issues/56)
+Pull Request: [#66](https://github.com/CaenCamp/jobs-caen-camp/pull/66)
+
+## Statut
+
+2020-04-22 proposed
+
+## Contexte et énoncé du problème
+
+Comme le précise l'[issue 55](https://github.com/CaenCamp/jobs-caen-camp/issues/55),
+une mise à jour de React-admin a mis en question le format des paramètres
+de pagination et de tri.
+
+
+Le paramètre de tri actuel est alors un tableau stringifié de la forme `['title', 'ASC']`,
+ce qui donne des requêtes de la forme :
+
+```
+/api/organizations?sort=%5B%22title%22%2C%22DESC%22%5D
+```
+
+Comment parser un tableau stringifié sans aller à l'encontre des
+[bonnes pratiques](https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/) ?
+
+
+
+
+
+
+Le tri est traité comme le paramètre `sort`, c'est un tableau stringifié,
+ici `["title", "DESC"]`.
+Pour simplifier la syntaxe des requêtes depuis le front-end, nous avons scindé ce paramètres en deux paramètres, sortBy et orderBy.
+
+Ce parti-pris améliore la lisibilité du contrat OpenAPI et simplifie la rédaction de la requête pour le front-end.
+
+[Décrivez le contexte et l'énoncé du problème, par exemple, sous forme libre en deux ou trois phrases. Vous pouvez vouloir articuler le problème sous forme de question].
+
+
+## Options envisagées
+
+Scinder le paramètre de tri `sort` en deux paramètres distincts : `sortBy` et `orderBy`.
+La requête sera de la forme :
+
+```
+api/organizations?sortBy=title&orderBy=DESC
+```
+
+
+## Résultat de la décision
+
+Cette scission des paramètres est retenue.
+
+### Conséquences positives
+
+* Contrat OpenAPI plus lisible => interface swagger améliorée
+* Simplification du code (pas besoin de parser un tableau)
+
+
+### Conséquences négatives
+
+Après la [refonte des paramètres de pagination](https://github.com/CaenCamp/jobs-caen-camp/pull/62)
+et cette refonte du tri, la
+[refonte des filtres de l'API](https://github.com/CaenCamp/jobs-caen-camp/issues/57)
+est désormais quasi-nécessaire, par souci d'harmonisation.
+
+
+## Liens
+
+-   [Ressources][best practices for designing a pragmatic restful api - pagination](https://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#pagination)
+-   [Ressources][rest api design: filtering, sorting, and pagination - pagination](https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/#pagination)

--- a/tests-e2e/api/job-postings.spec.js
+++ b/tests-e2e/api/job-postings.spec.js
@@ -54,14 +54,14 @@ describe('JobPostings API Endpoints', () => {
                 });
         });
 
-        it('devrait pouvoir renvoyer une liste ordonnée par title avec paramètres sort [title, DESC]', async () => {
+        it('devrait pouvoir renvoyer une liste ordonnée par title avec paramètres { sortBy: title, orderBy: DESC }', async () => {
             expect.hasAssertions();
             await frisby
                 .get(
-                    `http://api:3001/api/job-postings?sort=${JSON.stringify([
-                        'title',
-                        'DESC',
-                    ])}`
+                    `http://api:3001/api/job-postings?${querystring.stringify({
+                        sortBy: 'title',
+                        orderBy: 'DESC',
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -95,14 +95,14 @@ describe('JobPostings API Endpoints', () => {
                 });
         });
 
-        it('devrait pouvoir renvoyer une liste ordonnée par date de dépôt avec paramètres sort [datePosted, ASC]', async () => {
+        it('devrait pouvoir renvoyer une liste ordonnée par date de dépôt avec paramètres { sortBy: "datePosted", orderBy: "ASC"', async () => {
             expect.hasAssertions();
             await frisby
                 .get(
-                    `http://api:3001/api/job-postings?sort=${JSON.stringify([
-                        'datePosted',
-                        'ASC',
-                    ])}`
+                    `http://api:3001/api/job-postings?${querystring.stringify({
+                        sortBy: 'datePosted',
+                        orderBy: 'ASC',
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -136,14 +136,14 @@ describe('JobPostings API Endpoints', () => {
                 });
         });
 
-        it("devrait pouvoir renvoyer une liste ordonnée par code postal de l'entreprise [hiringOrganizationPostalCode, ASC]", async () => {
+        it("devrait pouvoir renvoyer une liste ordonnée par code postaux ascendant de l'entreprise hiringOrganizationPostalCode", async () => {
             expect.hasAssertions();
             await frisby
                 .get(
-                    `http://api:3001/api/job-postings?sort=${JSON.stringify([
-                        'hiringOrganizationPostalCode',
-                        'ASC',
-                    ])}`
+                    `http://api:3001/api/job-postings?${querystring.stringify({
+                        sortBy: 'hiringOrganizationPostalCode',
+                        orderBy: 'ASC',
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -237,7 +237,10 @@ describe('JobPostings API Endpoints', () => {
                 .get(
                     `http://api:3001/api/job-postings?filters=${JSON.stringify({
                         title: 'Lead',
-                    })}&sort=${JSON.stringify(['title', 'DESC'])}`
+                    })}&${querystring.stringify({
+                        sortBy: 'title',
+                        orderBy: 'DESC',
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(
@@ -272,7 +275,10 @@ describe('JobPostings API Endpoints', () => {
                 .get(
                     `http://api:3001/api/job-postings?filters=${JSON.stringify({
                         hiringOrganizationPostalCode: 14,
-                    })}&sort=${JSON.stringify(['title', 'DESC'])}`
+                    })}&${querystring.stringify({
+                        sortBy: 'title',
+                        orderBy: 'DESC',
+                    })}`
                 )
                 .expect('status', 200)
                 .expect(

--- a/tests-e2e/api/organizations.spec.js
+++ b/tests-e2e/api/organizations.spec.js
@@ -116,14 +116,14 @@ describe('Organizations API Endpoints', () => {
                 });
         });
 
-        it('devrait accepter un parametre de requête "sort" pour le tri', async () => {
+        it('devrait accepter des paramètres sortBy et orderBy pour le tri', async () => {
             expect.hasAssertions();
             await frisby
                 .get(
-                    `http://api:3001/api/organizations?sort=${JSON.stringify([
-                        'name',
-                        'ASC',
-                    ])}`
+                    `http://api:3001/api/organizations?${querystring.stringify({
+                        sortBy: 'name',
+                        orderBy: 'ASC',
+                    })}`
                 )
                 .expect('status', 200)
                 .then((resp) => {
@@ -134,10 +134,10 @@ describe('Organizations API Endpoints', () => {
                 });
             await frisby
                 .get(
-                    `http://api:3001/api/organizations?sort=${JSON.stringify([
-                        'name',
-                        'DESC',
-                    ])}`
+                    `http://api:3001/api/organizations?${querystring.stringify({
+                        sortBy: 'name',
+                        orderBy: 'DESC',
+                    })}`
                 )
                 .then((resp) => {
                     expect(resp.json).toHaveLength(3);


### PR DESCRIPTION
# Description

PR réalisé avec L'objectif est de refondre les paramètres de tri de l'API. La requête est jusqu'à présent de la forme :

```
/api/organizations?sort=%5B%22title%22%2C%22DESC%22%5D
```

Le tri est traité comme le paramètre `sort`, c'est un tableau stringifié,
ici `["title", "DESC"]`.

Pour des raisons de compatibilité avec React-Admin et afin d'être au
plus prêt des bonnes pratiques, il a été décidé de supprimer le paramètre `sort`
au profit de ses deux éléments, devenus les paramètres `sortBy` et `orderBy`.

La requête devient ainsi davantage lisible :

```
api/organizations?sortBy=title&orderBy=DESC
```

# Related Issue

[Refonte du tri de l'API #56](https://github.com/CaenCamp/jobs-caen-camp/issues/56)

- [x] Rédiger ce lien dans les règles de l'art.


# ToDo list:

-   [x]  Reprendre la gestion du tri dans les router.s de job-posting et organization
-   [x]  Reprendre la gestion du tri dans les repository de job-posting et organization
-   [x]  Mettre à jour le contrat OpenAPI
-   [x]  Mettre à jour les tests
-   [x]  Mettre à jour le dataProvider de react-admin
-   [x] Éditer un fichier ADR pour documenter la prise de décision.