### PR TITLE
Ajouter des pages Show à React-admin

### DIFF
--- a/apps/admin/src/App.js
+++ b/apps/admin/src/App.js
@@ -46,6 +46,7 @@ const App = () => (
                 }
                 icon={Organization.icon}
                 option={Organization.option}
+                show={Organization.show}
             />,
             <Resource
                 key="job-posting"
@@ -57,6 +58,7 @@ const App = () => (
                 }
                 icon={JobPosting.icon}
                 option={JobPosting.option}
+                show={Organization.show}
             />,
         ]}
     </Admin>

--- a/apps/admin/src/App.js
+++ b/apps/admin/src/App.js
@@ -58,7 +58,7 @@ const App = () => (
                 }
                 icon={JobPosting.icon}
                 option={JobPosting.option}
-                show={Organization.show}
+                show={JobPosting.show}
             />,
         ]}
     </Admin>

--- a/apps/admin/src/job-posting/List.js
+++ b/apps/admin/src/job-posting/List.js
@@ -70,7 +70,7 @@ export const JobPostingList = ({ permissions, ...props }) => {
             bulkActionButtons={false}
             title="Liste des Offres d'Emploi"
         >
-            <Datagrid rowClik="show">
+            <Datagrid rowClick="show">
                 <TextField source="title" label="Titre de l'offre" />
                 <TextField source="employmentType" label="Type de contrat" />
                 <ReferenceField

--- a/apps/admin/src/job-posting/List.js
+++ b/apps/admin/src/job-posting/List.js
@@ -70,7 +70,7 @@ export const JobPostingList = ({ permissions, ...props }) => {
             bulkActionButtons={false}
             title="Liste des Offres d'Emploi"
         >
-            <Datagrid>
+            <Datagrid rowClik="show">
                 <TextField source="title" label="Titre de l'offre" />
                 <TextField source="employmentType" label="Type de contrat" />
                 <ReferenceField

--- a/apps/admin/src/job-posting/Show.js
+++ b/apps/admin/src/job-posting/Show.js
@@ -5,30 +5,23 @@ export const JobPostingShow = (props) => {
     return (
         <Show title="Vue de l'offre d'emploi" {...props}>
             <SimpleShowLayout>
-                <TextField source="title:%l%" label="Filtre par titre" />
+                <TextField source="title" label="Filtre par titre" />
                 <TextField source="employmentType" label="Type de contrat" />
                 <TextField
-                    source="hiringOrganizationName:%l%"
+                    source="hiringOrganizationName"
                     label="Nom d'entreprise"
                 />
                 <TextField
-                    source="hiringOrganizationAddressLocality:l%"
+                    source="hiringOrganizationAddressLocality"
                     label="Ville de l'entreprise"
                 />
-                <TextField
-                    source="hiringOrganizationPostalCode:l%"
+                <DateField
+                    source="hiringOrganizationPostalCode"
                     label="Code postal de l'entreprise"
                 />
 
-                <DateField source="datePosted:lte" label="Postée avant le" />
-                <TextField source="datePosted:gte" label="Postée après le" />
-                <TextField source="jobStartDate:lte" label="Commence avant" />
-                <TextField source="jobStartDate:gte" label="Commence après" />
-                <TextField
-                    source="validThrough_before"
-                    label="Valide jusqu'au"
-                />
-                <TextField source="validThrough:gte" label="Valide après le" />
+                <DateField source="jobStartDate" label="Commence avant" />
+                <DateField source="validThrough" label="Valide jusqu'au" />
             </SimpleShowLayout>
         </Show>
     );

--- a/apps/admin/src/job-posting/Show.js
+++ b/apps/admin/src/job-posting/Show.js
@@ -1,6 +1,13 @@
 import React from 'react';
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import {
+    Show,
+    SimpleShowLayout,
+    TextField,
+    DateField,
+    UrlField,
+} from 'react-admin';
 import { PropTypes } from 'prop-types';
+import DisplayAddress from '../toolbox/DispayAddress';
 
 const JobPostingTitle = ({ record }) => {
     return <span>{record ? `${record.title}` : ''}</span>;
@@ -15,23 +22,30 @@ export const JobPostingShow = (props) => {
     return (
         <Show title={<JobPostingTitle />} {...props}>
             <SimpleShowLayout>
-                <TextField source="title" label="Filtre par titre" />
+                <TextField source="title" label="titre" />
+                <UrlField source="url" label="URL de l'offre" />
                 <TextField source="employmentType" label="Type de contrat" />
+                <TextField
+                    source="hiringOrganization.name"
+                    label="Proposé par"
+                />
+                <TextField
+                    source="experienceRequirements"
+                    label="Expérience requise"
+                />
                 <TextField source="skills" label="compétences demandées" />
-                <DateField source="jobStartDate" label="Commence avant" />
-                <DateField source="validThrough" label="Valide jusqu'au" />
-                <TextField
-                    source="hiringOrganizationName"
-                    label="Nom d'entreprise"
-                />
-                <TextField
-                    source="hiringOrganizationAddressLocality"
-                    label="Ville de l'entreprise"
-                />
 
-                <TextField
-                    source="hiringOrganizationPostalCode"
-                    label="Code postal de l'entreprise"
+                <DateField
+                    source="jobStartDate"
+                    label="Date de prise de poste"
+                />
+                <DateField source="validThrough" label="Valide jusqu'au" />
+                <DisplayAddress
+                    label="adresse"
+                    streetAddress="hiringOrganization.address.streetAddress"
+                    postalCode="hiringOrganization.address.postalCode"
+                    addressLocality="hiringOrganization.address.addressLocality"
+                    addressCountry="hiringOrganization.address.addressCountry"
                 />
             </SimpleShowLayout>
         </Show>

--- a/apps/admin/src/job-posting/Show.js
+++ b/apps/admin/src/job-posting/Show.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+
+export const JobPostingShow = (props) => {
+    return (
+        <Show title="Vue de l'offre d'emploi" {...props}>
+            <SimpleShowLayout>
+                <TextField source="title:%l%" label="Filtre par titre" />
+                <TextField source="employmentType" label="Type de contrat" />
+                <TextField
+                    source="hiringOrganizationName:%l%"
+                    label="Nom d'entreprise"
+                />
+                <TextField
+                    source="hiringOrganizationAddressLocality:l%"
+                    label="Ville de l'entreprise"
+                />
+                <TextField
+                    source="hiringOrganizationPostalCode:l%"
+                    label="Code postal de l'entreprise"
+                />
+
+                <DateField source="datePosted:lte" label="Postée avant le" />
+                <TextField source="datePosted:gte" label="Postée après le" />
+                <TextField source="jobStartDate:lte" label="Commence avant" />
+                <TextField source="jobStartDate:gte" label="Commence après" />
+                <TextField
+                    source="validThrough_before"
+                    label="Valide jusqu'au"
+                />
+                <TextField source="validThrough:gte" label="Valide après le" />
+            </SimpleShowLayout>
+        </Show>
+    );
+};

--- a/apps/admin/src/job-posting/Show.js
+++ b/apps/admin/src/job-posting/Show.js
@@ -1,12 +1,25 @@
 import React from 'react';
 import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import { PropTypes } from 'prop-types';
+
+const JobPostingTitle = ({ record }) => {
+    return <span>{record ? `${record.title}` : ''}</span>;
+};
+JobPostingTitle.propTypes = {
+    record: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+    }),
+};
 
 export const JobPostingShow = (props) => {
     return (
-        <Show title="Vue de l'offre d'emploi" {...props}>
+        <Show title={<JobPostingTitle />} {...props}>
             <SimpleShowLayout>
                 <TextField source="title" label="Filtre par titre" />
                 <TextField source="employmentType" label="Type de contrat" />
+                <TextField source="skills" label="compétences demandées" />
+                <DateField source="jobStartDate" label="Commence avant" />
+                <DateField source="validThrough" label="Valide jusqu'au" />
                 <TextField
                     source="hiringOrganizationName"
                     label="Nom d'entreprise"
@@ -15,13 +28,11 @@ export const JobPostingShow = (props) => {
                     source="hiringOrganizationAddressLocality"
                     label="Ville de l'entreprise"
                 />
-                <DateField
+
+                <TextField
                     source="hiringOrganizationPostalCode"
                     label="Code postal de l'entreprise"
                 />
-
-                <DateField source="jobStartDate" label="Commence avant" />
-                <DateField source="validThrough" label="Valide jusqu'au" />
             </SimpleShowLayout>
         </Show>
     );

--- a/apps/admin/src/job-posting/index.js
+++ b/apps/admin/src/job-posting/index.js
@@ -1,5 +1,5 @@
 import JobPostingIcon from '@material-ui/icons/EventSeat';
-
+import { JobPostingShow } from './Show';
 import { JobPostingList } from './List';
 import { JobPostingEdit } from './Edit';
 import { JobPostingCreate } from './Create';
@@ -16,5 +16,6 @@ export default {
     edit: JobPostingEdit,
     icon: JobPostingIcon,
     list: JobPostingList,
+    show: JobPostingShow,
     options: { label: "Offres d'emploi" },
 };

--- a/apps/admin/src/organization/List.js
+++ b/apps/admin/src/organization/List.js
@@ -61,7 +61,7 @@ export const OrganizationList = ({ permissions, ...props }) => {
             bulkActionButtons={false}
             title="Liste des Entreprises"
         >
-            <Datagrid rowClik="show">
+            <Datagrid rowClick="show">
                 <OrganizationLogo label="Logo" />
                 <TextField source="name" label="Nom de l'entreprise" />
                 <OrganizationAddress label="Adresse" />

--- a/apps/admin/src/organization/List.js
+++ b/apps/admin/src/organization/List.js
@@ -61,7 +61,7 @@ export const OrganizationList = ({ permissions, ...props }) => {
             bulkActionButtons={false}
             title="Liste des Entreprises"
         >
-            <Datagrid>
+            <Datagrid rowClik="show">
                 <OrganizationLogo label="Logo" />
                 <TextField source="name" label="Nom de l'entreprise" />
                 <OrganizationAddress label="Adresse" />

--- a/apps/admin/src/organization/Show.js
+++ b/apps/admin/src/organization/Show.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Show, SimpleShowLayout, TextField } from 'react-admin';
+
+// Todo :
+// const OrganizationName = ({ record }) => {
+//     return <span>{record ? `"${record.name}"` : ''}</span>;
+// };
+
+export const OrganizationShow = (props) => {
+    return (
+        // to add :
+        // <Show title={<OrganizationName />} {...props}></Show>
+        <Show title="vue de l'entreprise" {...props}>
+            <SimpleShowLayout>
+                {/* todo: LOGO */}
+                <TextField label="Nom de l'entreprise" source="name" />
+                <TextField label="Email principal" source="email" />
+                <TextField label="Url du site web" source="url" />
+                <TextField label="Présentation" source="description" />
+                <TextField label="adresse" source="address" />
+
+                <TextField
+                    label="Nom du contact des offres d'emploi"
+                    source="contact_name"
+                />
+                <TextField
+                    label="Email du contact des offres d'emploi"
+                    source="contact_email"
+                />
+                <TextField
+                    label="Téléphone du contact des offres d'emploi"
+                    source="contact_phone"
+                />
+            </SimpleShowLayout>
+        </Show>
+    );
+};

--- a/apps/admin/src/organization/Show.js
+++ b/apps/admin/src/organization/Show.js
@@ -4,7 +4,7 @@ import { PropTypes } from 'prop-types';
 
 // Todo :
 const OrganizationName = ({ record }) => {
-    return <span>{record ? `"${record.name}"` : ''}</span>;
+    return <span>{record ? `${record.name}` : ''}</span>;
 };
 OrganizationName.propTypes = {
     record: PropTypes.shape({

--- a/apps/admin/src/organization/Show.js
+++ b/apps/admin/src/organization/Show.js
@@ -1,23 +1,65 @@
 import React from 'react';
 import { Show, SimpleShowLayout, TextField } from 'react-admin';
+import { PropTypes } from 'prop-types';
 
 // Todo :
-// const OrganizationName = ({ record }) => {
-//     return <span>{record ? `"${record.name}"` : ''}</span>;
-// };
+const OrganizationName = ({ record }) => {
+    return <span>{record ? `"${record.name}"` : ''}</span>;
+};
+OrganizationName.propTypes = {
+    record: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+    }),
+};
+
+const DisplayAddress = ({ record }) => {
+    return record && record.address ? (
+        <p>
+            {record.address.streetAddress} <br />
+            {record.address.postalCode} {record.address.addressLocality}{' '}
+            {record.address.addressCountry}
+        </p>
+    ) : (
+        `Pas d'addresse pour "${record.name}"`
+    );
+};
+DisplayAddress.propTypes = {
+    record: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        address: PropTypes.shape({
+            addressCountry: PropTypes.string,
+            addressLocality: PropTypes.string,
+            postalCode: PropTypes.string,
+            streetAddress: PropTypes.string,
+        }),
+    }),
+};
+
+const OrganizationLogo = ({ record }) => {
+    return record && record.image ? (
+        <img src={record.image} height="50" alt={record.name} />
+    ) : (
+        `Pas d'image pour "${record.name}"`
+    );
+};
+OrganizationLogo.propTypes = {
+    record: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        image: PropTypes.string,
+    }),
+};
 
 export const OrganizationShow = (props) => {
     return (
         // to add :
-        // <Show title={<OrganizationName />} {...props}></Show>
-        <Show title="vue de l'entreprise" {...props}>
+        <Show title={<OrganizationName />} {...props}>
             <SimpleShowLayout>
-                {/* todo: LOGO */}
+                <OrganizationLogo label="logo" />
                 <TextField label="Nom de l'entreprise" source="name" />
                 <TextField label="Email principal" source="email" />
                 <TextField label="Url du site web" source="url" />
                 <TextField label="Présentation" source="description" />
-                <TextField label="adresse" source="address" />
+                {<DisplayAddress />}
 
                 <TextField
                     label="Nom du contact des offres d'emploi"
@@ -34,4 +76,7 @@ export const OrganizationShow = (props) => {
             </SimpleShowLayout>
         </Show>
     );
+};
+OrganizationShow.propTypes = {
+    address: PropTypes.object,
 };

--- a/apps/admin/src/organization/Show.js
+++ b/apps/admin/src/organization/Show.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Show, SimpleShowLayout, TextField } from 'react-admin';
+import { Show, SimpleShowLayout, TextField, UrlField } from 'react-admin';
 import { PropTypes } from 'prop-types';
+import DisplayAddress from '../toolbox/DispayAddress';
 
 // Todo :
 const OrganizationName = ({ record }) => {
@@ -9,29 +10,6 @@ const OrganizationName = ({ record }) => {
 OrganizationName.propTypes = {
     record: PropTypes.shape({
         name: PropTypes.string.isRequired,
-    }),
-};
-
-const DisplayAddress = ({ record }) => {
-    return record && record.address ? (
-        <p>
-            {record.address.streetAddress} <br />
-            {record.address.postalCode} {record.address.addressLocality}{' '}
-            {record.address.addressCountry}
-        </p>
-    ) : (
-        `Pas d'addresse pour "${record.name}"`
-    );
-};
-DisplayAddress.propTypes = {
-    record: PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        address: PropTypes.shape({
-            addressCountry: PropTypes.string,
-            addressLocality: PropTypes.string,
-            postalCode: PropTypes.string,
-            streetAddress: PropTypes.string,
-        }),
     }),
 };
 
@@ -55,23 +33,17 @@ export const OrganizationShow = (props) => {
         <Show title={<OrganizationName />} {...props}>
             <SimpleShowLayout>
                 <OrganizationLogo label="logo" />
-                <TextField label="Nom de l'entreprise" source="name" />
+                <TextField addlabel="false" source="name" />
                 <TextField label="Email principal" source="email" />
-                <TextField label="Url du site web" source="url" />
+                <UrlField label="Url du site web" source="url" />
                 <TextField label="Présentation" source="description" />
-                {<DisplayAddress />}
 
-                <TextField
-                    label="Nom du contact des offres d'emploi"
-                    source="contact_name"
-                />
-                <TextField
-                    label="Email du contact des offres d'emploi"
-                    source="contact_email"
-                />
-                <TextField
-                    label="Téléphone du contact des offres d'emploi"
-                    source="contact_phone"
+                <DisplayAddress
+                    label="adresse"
+                    streetAddress="address.streetAddress"
+                    postalCode="address.postalCode"
+                    addressLocality="address.addressLocality"
+                    addressCountry="address.addressCountry"
                 />
             </SimpleShowLayout>
         </Show>

--- a/apps/admin/src/organization/index.js
+++ b/apps/admin/src/organization/index.js
@@ -3,11 +3,13 @@ import OrganizationIcon from '@material-ui/icons/People';
 import { OrganizationList } from './List';
 import { OrganizationEdit } from './Edit';
 import { OrganizationCreate } from './Create';
+import { OrganizationShow } from './Show';
 
 export default {
     create: OrganizationCreate,
     edit: OrganizationEdit,
     icon: OrganizationIcon,
     list: OrganizationList,
+    show: OrganizationShow,
     options: { label: 'Entreprises' },
 };

--- a/apps/admin/src/toolbox/DispayAddress.js
+++ b/apps/admin/src/toolbox/DispayAddress.js
@@ -32,7 +32,7 @@ const AddressField = ({
 };
 
 AddressField.propTypes = {
-    className: PropTypes.string.isRequired,
+    className: PropTypes.string,
     addressCountry: PropTypes.string,
     addressLocality: PropTypes.string,
     postalCode: PropTypes.string,

--- a/apps/admin/src/toolbox/DispayAddress.js
+++ b/apps/admin/src/toolbox/DispayAddress.js
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import pure from 'recompose/pure';
+import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
+import get from 'lodash/get';
+
+const AddressField = ({
+    className,
+    record = {},
+    streetAddress,
+    postalCode,
+    addressLocality,
+    addressCountry,
+    ...rest
+}) => {
+    const street = get(record, streetAddress);
+    const postal = get(record, postalCode);
+    const locality = get(record, addressLocality);
+    const country = get(record, addressCountry);
+
+    return (
+        <Typography
+            component="span"
+            variant="body2"
+            className={className}
+            {...rest}
+        >
+            {street} <br />
+            {postal} {locality} {country}
+        </Typography>
+    );
+};
+
+AddressField.propTypes = {
+    className: PropTypes.string.isRequired,
+    addressCountry: PropTypes.string,
+    addressLocality: PropTypes.string,
+    postalCode: PropTypes.string,
+    streetAddress: PropTypes.string,
+    record: PropTypes.object,
+};
+
+// wat? TypeScript looses the displayName if we don't set it explicitly
+AddressField.displayName = 'AddressField';
+
+const EnhancedAddressField = pure(AddressField);
+
+EnhancedAddressField.defaultProps = {
+    addLabel: true,
+};
+
+EnhancedAddressField.propTypes = {
+    ...Typography.propTypes,
+};
+
+EnhancedAddressField.displayName = 'EnhancedAddressField';
+
+export default EnhancedAddressField;


### PR DESCRIPTION
# Description
Dans le but d'avoir un front temporaire mais utilisable, il ne manque à React-admin que l'option d'afficher les offres d'emplois et les entreprises individuellement.

C'est réalisable grâce à [Show de react-admin](https://marmelab.com/react-admin/Show.html)


# ToDo list:
-   [x] Créer les composants react `Show` pour `job-posting` et `organization`
-   [x] Faire fonctionner le tout.

